### PR TITLE
Fix YAML paths section

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,13 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize]
     # Optional: Only run on specific file changes
-    # paths:
-       - "src/**/*.ts"
-       - "src/**/*.tsx"
-       - "src/**/*.js"
-       - "src/**/*.jsx"
-       - "**/*.go"
-       - "**/*.py"
+    paths:
+      - "src/**/*.ts"
+      - "src/**/*.tsx"
+      - "src/**/*.js"
+      - "src/**/*.jsx"
+      - "**/*.go"
+      - "**/*.py"
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary
- reintroduce the example `paths` entries as an active list in `claude-code-review.yml`
- keep YAML valid

## Testing
- `python3 - <<'PY'
import yaml
yaml.safe_load(open('.github/workflows/claude-code-review.yml'))
print('YAML parsed OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68693353a50c83258b0872e770715a74