### PR TITLE
Check off TODO and add envsetup script

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 
 - [x] Clean up the tables and dot points in the README so that they are in proper markdown format. They are in a mixture of lines, unicode dotpoints, tab separated texts and so on
 
-- [ ] Create a separate to-do list file with everything that was in the README.md file (and remove it from README.md)
+- [x] Create a separate to-do list file with everything that was in the README.md file (and remove it from README.md)
 
 - [ ] Create an `envsetup.sh` file with the necessary software that we will use for the pipeline
 

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Install base tools
+sudo apt-get update
+sudo apt-get install -y nodejs npm ffmpeg golang-go awscli jq
+
+# Install Marp CLI for slide rendering
+sudo npm install -g @marp-team/marp-cli
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- mark the todo item for migrating list from README to `TODO.md` as done
- add an initial `envsetup.sh` script for installing development tools

## Testing
- `go vet ./...` *(fails: no Go module)*

------
https://chatgpt.com/codex/tasks/task_e_686997a04470832599c874ee94b81bf7