### PR TITLE
Split ITIL overview script into slide files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ into SCORM or e-book formats. The step-by-step checklist is maintained in [TODO.
 - `cmd/voicer/main.go` was pulled in from another project, and shows how to call the ElevenLabs API 
 
 - `raw-notes.txt` some text that I wrote that is relevant to a few topics
+- `docs/narrative-guidelines.md` explains how each slide's script lives in its own file and offers tips on style and word counts
 
 
 ## Repository Structure

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@ Use the checklist below to track progress for each part.
 #### Part 1 – ITIL Foundations
 - [x] Outline objectives and key topics
 - [x] Create to-do list items for each topic to draft slides and write narratives
-- [ ] Draft slides and narrative: Overview of ITIL 4 and why it matters
+- [x] Draft slides and narrative: Overview of ITIL 4 and why it matters
 - [ ] Draft slides and narrative: Service value chain and continual improvement
 - [ ] Draft slides and narrative: Incident vs request fulfilment workflows
 - [ ] Draft slides and narrative: Escalation paths and support tiers (L1/L2/L3)

--- a/content/part-01/overview/narratives/01-intro.md
+++ b/content/part-01/overview/narratives/01-intro.md
@@ -1,0 +1,5 @@
+Speaker 1: [friendly] Welcome to our quick tour of ITIL 4. Think of this first slide as the stage curtain rising. Behind it lies a set of practices that guide how large organisations deliver tech support.
+
+Speaker 2: [cheerful] If you're new to the scene, picture ITIL like a city's traffic system—lanes, signs and intersections that keep everything flowing. Without it, we'd have gridlock every time an incident pops up.
+
+Speaker 1: [light-hearted] We'll stick to the essentials, sprinkling in some humour so you won't nod off. By the end of this course you'll see why ITIL lingo is your ticket to a smoother IT career.

--- a/content/part-01/overview/narratives/02-what-is-itil.md
+++ b/content/part-01/overview/narratives/02-what-is-itil.md
@@ -1,0 +1,5 @@
+Speaker 2: [curiously] ITIL once stood for the Information Technology Infrastructure Library, but these days it's simply ITIL 4—a flexible set of practices focused on value. Imagine a cookbook for service management, packed with recipes like incident resolution and change enablement.
+
+Speaker 1: [thoughtful] Each ingredient is designed to balance stability and innovation. When you follow the book, you avoid the "too many cooks" problem and keep services tasty.
+
+Speaker 2: [amused] So next time someone says "ITIL," picture a restaurant kitchen. Everyone has a station, the meals come out on time, and customers leave happy.

--- a/content/part-01/overview/narratives/03-career.md
+++ b/content/part-01/overview/narratives/03-career.md
@@ -1,0 +1,5 @@
+Speaker 1: [encouraging] You're probably wondering how this applies to landing a job. Recruiters love candidates who speak the language of ITIL because it means less hand-holding on day one.
+
+Speaker 2: [enthusiastic] Think of it like joining a sports team mid-season. If you already know the playbook, you can jump right into the action. You'll deal with incidents, requests and changes in any support role, so learning the plays now saves you from awkward fumbles later.
+
+Speaker 1: [light chuckle] Plus, tossing around a few ITIL terms at interviews might just make you sound like the pro you are becoming.

--- a/content/part-01/overview/narratives/04-takeaway.md
+++ b/content/part-01/overview/narratives/04-takeaway.md
@@ -1,0 +1,5 @@
+Speaker 2: [reflective] The real takeaway is that ITIL 4 gives you a sturdy framework for managing technology services. It's like having a trusty toolkit when something breaks—you don't have to guess which wrench fits.
+
+Speaker 1: [warm] As you explore the rest of this course, keep that toolkit analogy in mind. You won't memorise every tool on day one, but knowing they exist means you're ready for whatever problems pop up.
+
+Speaker 2: [smiling] So buckle up and enjoy the ride. The better you understand ITIL now, the easier every other topic will become.

--- a/content/part-01/overview/slides.md
+++ b/content/part-01/overview/slides.md
@@ -1,0 +1,32 @@
+---
+marp: true
+title: Overview of ITIL 4
+---
+
+# Overview of ITIL 4
+
+*How modern service management underpins IT operations*
+
+---
+
+## What is ITIL 4?
+
+- Latest evolution of the IT Infrastructure Library
+- Focus on value co‑creation through service management
+- Aligns IT with broader business objectives
+
+---
+
+## Why it matters for your career
+
+- Common language in enterprise IT environments
+- Demonstrates understanding of structured processes
+- Builds foundation for incident, change and problem management
+
+---
+
+## Key takeaway
+
+Grasping ITIL 4 concepts helps new professionals navigate
+real-world service teams and collaborate effectively.
+

--- a/docs/narrative-guidelines.md
+++ b/docs/narrative-guidelines.md
@@ -1,0 +1,7 @@
+# Narrative Guidelines
+
+The narrative files under `content/**/` are the verbatim scripts fed into the text-to-speech engine. Each slide normally runs for about a minute, so aim for roughly one hundred words per slide, written in full sentences.
+
+Because every line is spoken, **do not include headings or bullet points**. Instead, save a separate `.md` file for each slide in a `narratives/` folder next to the slide deck. Name them `01.md`, `02.md` and so on to match the slide order.
+
+You may indicate delivery style with bracketed notes, e.g. `[excitedly]`, and split the script between "Speaker 1" and "Speaker 2" if you want a dialog. Keep the tone friendly and feel free to use analogies, humour and real-world examples to hold the listener's attention.


### PR DESCRIPTION
## Summary
- explain slide narratives are separate files in README
- update guidelines for how to structure narration scripts
- replace single ITIL overview narrative with four slide files written as dialogue

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_686a32d77b6c83259820e8c49aa17940