### PR TITLE
Expand major incident drill example with roles

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,7 @@ Use the checklist below to track progress for each part.
 - [x] Draft slides and narrative: Service value chain and continual improvement
 - [x] Draft slides and narrative: Incident vs request fulfilment workflows
 - [x] Draft slides and narrative: Escalation paths and support tiers (L1/L2/L3)
-- [ ] Draft slides and narrative: Major incident management drill
+- [x] Draft slides and narrative: Major incident management drill
 - [ ] Draft slides and narrative: ServiceNow as an ITIL visual guide
 - [ ] Draft slides and narrative: Job roles across the service lifecycle
 - [ ] Create quiz questions

--- a/content/part-01/major-incident-drill/narratives/01-intro.md
+++ b/content/part-01/major-incident-drill/narratives/01-intro.md
@@ -1,0 +1,3 @@
+Speaker 1: Welcome to our major incident drill. Think of it as a fire drill for IT—everyone needs to know their part before the real emergency hits.
+
+Speaker 2: We'll walk through a simulated outage so you can practice the motions without the adrenaline spike. The goal is to stay calm and restore service swiftly.

--- a/content/part-01/major-incident-drill/narratives/02-when-major.md
+++ b/content/part-01/major-incident-drill/narratives/02-when-major.md
@@ -1,0 +1,3 @@
+Speaker 2: A major incident is more than a glitch. It affects core services and usually drags multiple teams into the fight. Picture the checkout system rejecting every payment during a sale—that's major.
+
+Speaker 1: When you see widespread impact or a breached SLA on the horizon, escalate it and rally the right experts immediately.

--- a/content/part-01/major-incident-drill/narratives/03-architecture.md
+++ b/content/part-01/major-incident-drill/narratives/03-architecture.md
@@ -1,0 +1,4 @@
+Speaker 1: Let's map the checkout flow so everyone knows where problems can start.
+The web front end hits an API gateway, which then fans out to microservices for
+payments, inventory, and orders. Those services talk to a clustered database and
+ping the payment provider over the internet. Monitoring agents watch each step.

--- a/content/part-01/major-incident-drill/narratives/04-roles.md
+++ b/content/part-01/major-incident-drill/narratives/04-roles.md
@@ -1,0 +1,8 @@
+Speaker 2: A failure anywhere in that chain kicks off a big response.
+The incident commander coordinates efforts and sets priorities.
+A communications lead keeps executives and customers in the loop.
+Front-end and backend engineers dig into code issues.
+Database admins check queries and replication.
+Network ops verify connectivity and DNS.
+A liaison talks to the payment provider.
+Finally, the service desk fields user reports and keeps them updated.

--- a/content/part-01/major-incident-drill/narratives/05-running-drill.md
+++ b/content/part-01/major-incident-drill/narratives/05-running-drill.md
@@ -1,0 +1,5 @@
+Speaker 1: During the drill, assign each role quickly and follow the runbook.
+The incident commander leads, comms handles updates, and a scribe logs every step.
+
+Speaker 2: Treat it as the real thing—no shortcuts. The more accurately you rehearse,
+the smoother an actual outage will play out.

--- a/content/part-01/major-incident-drill/narratives/06-review.md
+++ b/content/part-01/major-incident-drill/narratives/06-review.md
@@ -1,0 +1,3 @@
+Speaker 2: Once the dust settles, gather the team to review what happened. Share successes, missteps, and any surprises.
+
+Speaker 1: Update the playbook based on those lessons and book another drill. Practice turns panic into muscle memory.

--- a/content/part-01/major-incident-drill/slides.md
+++ b/content/part-01/major-incident-drill/slides.md
@@ -1,0 +1,57 @@
+---
+marp: true
+title: Major Incident Management Drill
+---
+
+# Major Incident Management Drill
+*Staying calm when systems fail*
+
+---
+
+## When is it a major incident?
+- Impacts critical business services
+- Requires cross-team coordination
+- Needs immediate communication
+
+---
+
+## Example scenario
+- Checkout system fails across all regions
+- Users can't complete purchases
+- Mobilize database, network and app teams
+
+---
+
+## Checkout architecture
+- Web front end served from CDN
+- API gateway routing to microservices
+- Payment gateway integration
+- Inventory and order databases
+- Monitoring at each layer
+
+---
+
+## Who is involved?
+- Incident commander coordinates the response
+- Communications lead keeps stakeholders informed
+- Front-end and backend engineering teams
+- Database administrators
+- Network operations
+- Payment provider liaison
+- Service desk and customer support
+
+---
+
+## Running the drill
+- Assign clear roles fast
+- Follow the runbook step by step
+- Capture decisions and timelines
+
+---
+
+## After-action review
+- Share what went well and what didn't
+- Update the playbook accordingly
+- Schedule the next practice
+
+---


### PR DESCRIPTION
## Summary
- expand the major incident drill slide deck with checkout architecture and detailed roles
- describe the architecture and response roles in matching narratives
- reorganize narrative files to keep slide order

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bd3214b188325a7bd62b345653eb5