### PR TITLE
Website deployment pipeline

### DIFF
--- a/.github/workflows/run_sheets.yml
+++ b/.github/workflows/run_sheets.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DEPLOYMENT_SSH_KEY: ${{ secrets.DEPLOYMENT_SSH_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -15,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y nodejs npm ffmpeg jq fonts-dejavu-core
+          sudo apt-get install -y nodejs npm ffmpeg jq fonts-dejavu-core poppler-utils rsync
           sudo npm install -g @marp-team/marp-cli
           ./scripts/install_chrome.sh
           go mod download
@@ -31,6 +33,19 @@ jobs:
       - name: Generate run sheets
         run: |
           ./scripts/generate_run_sheets.sh
+      - name: Convert run sheets to HTML
+        run: |
+          ./scripts/generate_run_sheets_html.sh
+      - name: Prepare SSH key
+        if: env.DEPLOYMENT_SSH_KEY != ''
+        run: |
+          echo "$DEPLOYMENT_SSH_KEY" > /tmp/deploy_key
+          chmod 600 /tmp/deploy_key
+          echo "DEPLOYMENT_SSH_KEY=/tmp/deploy_key" >> $GITHUB_ENV
+      - name: Deploy website
+        if: env.DEPLOYMENT_SSH_KEY != ''
+        run: |
+          ./scripts/deploy_website.sh
       - uses: actions/upload-artifact@v4
         with:
           name: run-sheets

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@
 - [x] Create a separate to-do list file with everything that was in the README.md file (and remove it from README.md)
 
 - [x] Create an `envsetup.sh` file with the necessary software that we will use for the pipeline
+- [ ] Update `index.html` whenever the pipeline produces new artifacts
 
 **NOTE:** Each part should highlight relevant job roles, typical seniority levels, entry pathways, suitable personality traits, proportions of such roles in organisations and likely career progressions.
 

--- a/scripts/deploy_website.sh
+++ b/scripts/deploy_website.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+REMOTE_USER="professionalpractice"
+REMOTE_HOST="merah.cassia.ifost.org.au"
+REMOTE_DIR="/var/www/vhosts/professional-practice.industrial-linguistics.com/htdocs"
+SSH_KEY="$DEPLOYMENT_SSH_KEY"
+
+if [ -z "$SSH_KEY" ]; then
+  echo "DEPLOYMENT_SSH_KEY is not set" >&2
+  exit 1
+fi
+
+RSYNC_SSH="ssh -i $SSH_KEY -o StrictHostKeyChecking=no"
+rsync -avz -e "$RSYNC_SSH" website/ "$REMOTE_USER@$REMOTE_HOST:$REMOTE_DIR/"

--- a/scripts/generate_run_sheets_html.sh
+++ b/scripts/generate_run_sheets_html.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+OUTPUT_DIR="website/run-script"
+mkdir -p "$OUTPUT_DIR"
+INDEX_FILE="$OUTPUT_DIR/index.html"
+echo '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Run Script Resources</title></head><body><h1>Run Script Resources</h1><ul>' > "$INDEX_FILE"
+for pdf in run-sheets/*.pdf; do
+  [ -f "$pdf" ] || continue
+  base=$(basename "$pdf" .pdf)
+  dest_pdf="$OUTPUT_DIR/$base.pdf"
+  cp "$pdf" "$dest_pdf"
+  html_dir="$OUTPUT_DIR/$base"
+  mkdir -p "$html_dir"
+  pdftohtml -c -s -noframes "$pdf" "$html_dir/page" > /dev/null
+  mv "$html_dir/page.html" "$html_dir/index.html"
+  echo "<li><a href=\"$base.pdf\">$base.pdf</a> (<a href=\"$base/\">HTML</a>)</li>" >> "$INDEX_FILE"
+  echo "Converted $pdf to HTML in $html_dir"
+done
+echo '</ul></body></html>' >> "$INDEX_FILE"

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Professional Practice Artifacts</title>
+</head>
+<body>
+  <h1>Professional Practice Artifacts</h1>
+  <ul>
+    <li><a href="run-script/">Run Script resources</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a reminder in the TODO to update `index.html`
- create script to generate HTML versions of run‑sheet PDFs
- create script to deploy the generated website via SSH
- update CI workflow to convert PDFs to HTML and deploy
- add simple website skeleton with `index.html`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e20b87be88325bb87cd2274317dbd