### PR TITLE
Fix slide image overlap in run sheets

### DIFF
--- a/cmd/run_sheets/main.go
+++ b/cmd/run_sheets/main.go
@@ -96,7 +96,7 @@ func addTopic(pdf *gofpdf.Fpdf, part string, topicPath string, baseFont string, 
 	sort.Strings(narratives)
 
 	for i, img := range images {
-		pdf.ImageOptions(img, 15, pdf.GetY(), 180, 0, false, gofpdf.ImageOptions{ImageType: "PNG"}, 0, "")
+		pdf.ImageOptions(img, 15, pdf.GetY(), 180, 0, true, gofpdf.ImageOptions{ImageType: "PNG"}, 0, "")
 		pdf.Ln(2)
 		if i < len(narratives) {
 			b, err := os.ReadFile(narratives[i])


### PR DESCRIPTION
## Summary
- ensure slide images flow properly when generating run sheet PDFs

## Testing
- `go vet ./...`
- `go build ./cmd/run_sheets`
- `go build ./cmd/render-slides`


------
https://chatgpt.com/codex/tasks/task_e_686e66d5f594832590eb1342306a4db5