### PR TITLE
Add httpd.conf example for genius-of-crowds

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ into SCORM or e-book formats. The step-by-step checklist is maintained in [TODO.
 
 - `raw-notes.txt` some text that I wrote that is relevant to a few topics
 - `docs/narrative-guidelines.md` explains how each slide's script lives in its own file and offers tips on style and word counts
+- `docs/genius-of-crowds-httpd.md` documents the OpenBSD httpd configuration used for genius-of-crowds.com
 
 
 ## Repository Structure

--- a/docs/genius-of-crowds-httpd.md
+++ b/docs/genius-of-crowds-httpd.md
@@ -1,0 +1,28 @@
+# genius-of-crowds.com httpd.conf
+
+The following snippet shows the web server configuration for **genius-of-crowds.com**. It defines virtual hosts for plain HTTP and TLS, ACME challenge handling, and CGI execution.
+
+```httpd
+server "genius-of-crowds.com" {
+        log style combined
+        alias "app.genius-of-crowds.com"
+        alias "www.genius-of-crowds.com"
+        directory { auto index }
+        listen on $listen_addr port 80
+        listen on $listen_addr tls port 443
+        tls {
+            key "/etc/ssl/private/genius-of-crowds.com.key"  
+            certificate "/etc/ssl/genius-of-crowds.com.crt"
+        }
+        location "/.well-known/acme-challenge/*" {
+            root "/acme"
+            request strip 2
+        }  
+        root "/vhosts/genius-of-crowds.com/htdocs"
+        location "/cgi-bin/*" {
+            fastcgi
+            root "/vhosts/genius-of-crowds.com"
+        }  
+}
+```
+


### PR DESCRIPTION
## Summary
- add documentation for the OpenBSD httpd configuration of genius-of-crowds.com
- reference the config in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e690e42d483258afb18698a9dde8f