### PR TITLE
Add CI/CD pipeline design topic

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,7 @@ Use the checklist below to track progress for each part.
  - [x] Draft slides and narrative: DORA metrics and DevOps performance measurement
  - [x] Draft slides and narrative: Trunk-based development vs feature branching strategies
  - [x] Draft slides and narrative: CI/CD pipeline design principles and implementation
-- [ ] Draft slides and narrative: SRE error budgets and service level objectives
+ - [x] Draft slides and narrative: SRE error budgets and service level objectives
 - [ ] Draft slides and narrative: GitHub Actions workflows and automation
 - [ ] Draft slides and narrative: DevOps, SRE and platform engineering career paths
 - [ ] Create quiz questions

--- a/TODO.md
+++ b/TODO.md
@@ -50,7 +50,7 @@ Use the checklist below to track progress for each part.
 - [x] Create to-do list items for each topic to draft slides and write narratives
  - [x] Draft slides and narrative: DORA metrics and DevOps performance measurement
  - [x] Draft slides and narrative: Trunk-based development vs feature branching strategies
-- [ ] Draft slides and narrative: CI/CD pipeline design principles and implementation
+ - [x] Draft slides and narrative: CI/CD pipeline design principles and implementation
 - [ ] Draft slides and narrative: SRE error budgets and service level objectives
 - [ ] Draft slides and narrative: GitHub Actions workflows and automation
 - [ ] Draft slides and narrative: DevOps, SRE and platform engineering career paths

--- a/content/part-03/cicd-pipeline-design/narratives/01-intro.md
+++ b/content/part-03/cicd-pipeline-design/narratives/01-intro.md
@@ -1,2 +1,4 @@
-Speaker 1: Continuous integration and delivery turn code changes into deployable packages with minimal manual effort.
-Speaker 2: A reliable pipeline keeps teams shipping features confidently without tedious release ceremonies.
+Speaker 1: Picture manually copying files to dozens of servers after every tiny fix. It's slow, error-prone, and frankly a bit soul-crushing.
+Speaker 2: Exactly. Continuous integration and continuous delivery—CI/CD for short—evolved to end that pain. They let us package code changes automatically and push them to testing or production with a single command.
+Speaker 1: Even non-technical teams appreciate the reliability. Instead of wondering if the latest version actually made it to the customer site, everyone can see the pipeline status in real time.
+Speaker 2: Think of it like an assembly line in a factory. Once the pieces start moving, the machinery takes care of the rest, freeing people to focus on improving the product rather than shipping logistics.

--- a/content/part-03/cicd-pipeline-design/narratives/01-intro.md
+++ b/content/part-03/cicd-pipeline-design/narratives/01-intro.md
@@ -1,0 +1,2 @@
+Speaker 1: Continuous integration and delivery turn code changes into deployable packages with minimal manual effort.
+Speaker 2: A reliable pipeline keeps teams shipping features confidently without tedious release ceremonies.

--- a/content/part-03/cicd-pipeline-design/narratives/02-principles.md
+++ b/content/part-03/cicd-pipeline-design/narratives/02-principles.md
@@ -1,0 +1,2 @@
+Speaker 1: Start by automating every build, test and deployment step.
+Speaker 2: Build artifacts once and reuse them as they flow through environments, with fast feedback and security checks along the way.

--- a/content/part-03/cicd-pipeline-design/narratives/02-principles.md
+++ b/content/part-03/cicd-pipeline-design/narratives/02-principles.md
@@ -1,2 +1,4 @@
-Speaker 1: Start by automating every build, test and deployment step.
-Speaker 2: Build artifacts once and reuse them as they flow through environments, with fast feedback and security checks along the way.
+Speaker 1: At its core, a CI/CD pipeline takes every change and runs it through the same checklist—build the code, test it thoroughly, then deploy it in a predictable way.
+Speaker 2: Automating these steps removes guesswork and inconsistency. The trick is to build the application once, store that exact artifact, and promote it through test, staging, and production environments.
+Speaker 1: Quick feedback loops are essential. If a test fails minutes after a commit, you can fix the issue before it grows.
+Speaker 2: Security scans and quality gates slot neatly into this process as well, so new features never skip the basic health checks. The pipeline should become the trusted guardian that approves everything that ships.

--- a/content/part-03/cicd-pipeline-design/narratives/03-flow.md
+++ b/content/part-03/cicd-pipeline-design/narratives/03-flow.md
@@ -1,0 +1,2 @@
+Speaker 1: Each commit should trigger a fresh build in a clean environment.
+Speaker 2: Automated tests gate the path to staging and production, ensuring only proven code progresses.

--- a/content/part-03/cicd-pipeline-design/narratives/03-flow.md
+++ b/content/part-03/cicd-pipeline-design/narratives/03-flow.md
@@ -1,2 +1,4 @@
-Speaker 1: Each commit should trigger a fresh build in a clean environment.
-Speaker 2: Automated tests gate the path to staging and production, ensuring only proven code progresses.
+Speaker 1: Once a developer commits code, the pipeline springs into action. A clean environment spins up so any leftover files from previous builds can't cause trouble.
+Speaker 2: The code is compiled or packaged, then a suite of automated tests checks that nothing obvious broke. If those tests pass, the same package moves on to a staging area where more realistic checks occur.
+Speaker 1: Staging mirrors the production environment closely. It's where you might run smoke tests or manual reviews if needed.
+Speaker 2: Only when everything looks good does the pipeline promote the very same build to production. That consistent flow—from commit to build to test to deploy—means you always know exactly what you're releasing.

--- a/content/part-03/cicd-pipeline-design/narratives/04-github-actions.md
+++ b/content/part-03/cicd-pipeline-design/narratives/04-github-actions.md
@@ -1,2 +1,4 @@
-Speaker 1: A GitHub Actions workflow can orchestrate these steps in YAML.
-Speaker 2: Separate jobs for build, test and deploy keep things modular, while secrets store credentials safely.
+Speaker 1: One popular way to run a pipeline is through GitHub Actions. It's basically a set of instructions written in a simple YAML file that tells GitHub what to do whenever new code arrives.
+Speaker 2: You can define separate jobs for building, testing, and deploying. That separation keeps things tidy and makes it easy to see where a failure happens.
+Speaker 1: The workflow can also reuse community-created actions for common tasks like setting up a programming language or uploading artifacts.
+Speaker 2: And because sensitive information is stored in encrypted secrets, you don't have to hard-code passwords or access keys. It's like giving the pipeline a safe to keep its credentials locked away while it works.

--- a/content/part-03/cicd-pipeline-design/narratives/04-github-actions.md
+++ b/content/part-03/cicd-pipeline-design/narratives/04-github-actions.md
@@ -1,0 +1,2 @@
+Speaker 1: A GitHub Actions workflow can orchestrate these steps in YAML.
+Speaker 2: Separate jobs for build, test and deploy keep things modular, while secrets store credentials safely.

--- a/content/part-03/cicd-pipeline-design/narratives/05-takeaway.md
+++ b/content/part-03/cicd-pipeline-design/narratives/05-takeaway.md
@@ -1,0 +1,2 @@
+Speaker 1: The ultimate goal is continuous flow from commit to production.
+Speaker 2: By baking quality into the pipeline, teams move fast without leaving reliability to chance.

--- a/content/part-03/cicd-pipeline-design/narratives/05-takeaway.md
+++ b/content/part-03/cicd-pipeline-design/narratives/05-takeaway.md
@@ -1,2 +1,4 @@
-Speaker 1: The ultimate goal is continuous flow from commit to production.
-Speaker 2: By baking quality into the pipeline, teams move fast without leaving reliability to chance.
+Speaker 1: In the end, a solid pipeline is less about fancy tooling and more about building trust. Every time code flows smoothly from a developer's laptop to production, confidence grows across the team.
+Speaker 2: Automating the repetitive steps frees everyone to focus on quality and new ideas. Mistakes still happen, but the pipeline catches many of them before customers ever notice.
+Speaker 1: Think of it as a safety net and a speed booster rolled into one. Once you've experienced reliable CI/CD, it's hard to imagine going back to manual releases.
+Speaker 2: So the real takeaway is simple: invest in your pipeline early. It pays off with faster feedback, fewer surprises, and calmer midnight releases—or better yet, no midnight releases at all.

--- a/content/part-03/cicd-pipeline-design/slides.md
+++ b/content/part-03/cicd-pipeline-design/slides.md
@@ -1,0 +1,35 @@
+---
+marp: true
+title: CI/CD Pipeline Design Principles
+---
+
+# CI/CD Pipeline Design
+*Automating delivery from commit to production*
+
+---
+
+## Core principles
+- Automate build, test and deploy steps
+- Build once, deploy many times
+- Provide fast feedback on changes
+- Include security and quality gates
+
+---
+
+## Implementation flow
+- Trigger on source control events
+- Build artifacts in a clean environment
+- Run tests to validate changes
+- Deploy progressively through environments
+
+---
+
+## GitHub Actions example
+- YAML workflow triggered on push
+- Separate jobs for build, test and deploy
+- Reusable actions and encrypted secrets
+
+---
+
+## Key takeaway
+A well‑designed pipeline lets teams deliver code quickly and safely through automation and continuous feedback.

--- a/content/part-03/cicd-pipeline-design/slides.md
+++ b/content/part-03/cicd-pipeline-design/slides.md
@@ -8,6 +8,14 @@ title: CI/CD Pipeline Design Principles
 
 ---
 
+## Why CI/CD?
+- Manual deployments are slow and error-prone
+- Automation ensures repeatable releases
+- Quick feedback helps teams of any size
+- Lets engineers focus on features, not shipping chores
+
+---
+
 ## Core principles
 - Automate build, test and deploy steps
 - Build once, deploy many times
@@ -20,7 +28,7 @@ title: CI/CD Pipeline Design Principles
 - Trigger on source control events
 - Build artifacts in a clean environment
 - Run tests to validate changes
-- Deploy progressively through environments
+- Deploy progressively from dev to prod
 
 ---
 

--- a/content/part-03/sre-error-budgets/narratives/01-intro.md
+++ b/content/part-03/sre-error-budgets/narratives/01-intro.md
@@ -1,0 +1,3 @@
+Speaker 1: Imagine you promised your app would be available 99.9% of the time. That still allows roughly nine hours of downtime a year.
+Speaker 2: Site Reliability Engineering, or SRE, turns those promises into math we can track. The key tools are service level objectives, or SLOs, and the error budgets tied to them.
+Speaker 1: By defining how reliable a service must be, we can decide when it's safe to launch new features and when it's time to pause and fix instability.

--- a/content/part-03/sre-error-budgets/narratives/02-slo.md
+++ b/content/part-03/sre-error-budgets/narratives/02-slo.md
@@ -1,0 +1,3 @@
+Speaker 1: A service level objective is basically a reliability target, like "respond to user requests within two seconds 99% of the time." It sets clear expectations.
+Speaker 2: For non-technical folks, think of an SLO as a promise to customers. If we hit that goal, users stay happy. If we miss it, they notice glitches or slow pages.
+Speaker 1: We monitor these objectives continuously so we know if the service is drifting away from the acceptable range before customers complain.

--- a/content/part-03/sre-error-budgets/narratives/03-error-budgets.md
+++ b/content/part-03/sre-error-budgets/narratives/03-error-budgets.md
@@ -1,0 +1,3 @@
+Speaker 1: An error budget is the small slice of allowable failure built into an SLO. If our target is 99.9% uptime, that gives us about forty minutes of downtime each month.
+Speaker 2: As outages or performance issues occur, we "spend" that budget. When it's gone, engineering focuses on reliability work instead of shipping new features.
+Speaker 1: This approach keeps everyone aligned. Product managers see how instability eats into development time, while engineers know exactly when to slow their release pace.

--- a/content/part-03/sre-error-budgets/narratives/04-use.md
+++ b/content/part-03/sre-error-budgets/narratives/04-use.md
@@ -1,0 +1,3 @@
+Speaker 1: Error budgets aren't just for ops teams. They spark conversations about risk across the organization.
+Speaker 2: When the budget burns down faster than expected, it's a sign our releases might be too risky or our SLO is unrealistic.
+Speaker 1: Teams can agree to slow deployments, add more testing, or even adjust the SLO if customer impact warrants it. The data helps remove emotion from those decisions.

--- a/content/part-03/sre-error-budgets/narratives/05-takeaway.md
+++ b/content/part-03/sre-error-budgets/narratives/05-takeaway.md
@@ -1,0 +1,3 @@
+Speaker 1: The real win is shared language. SLOs and error budgets help teams quantify acceptable risk instead of arguing about perfection.
+Speaker 2: They also create breathing room. When you're under budget, you can innovate quickly. When it's nearly spent, stability becomes the priority.
+Speaker 1: By treating reliability like any other feature, SRE practices keep users happy and developers focused on the right work at the right time.

--- a/content/part-03/sre-error-budgets/slides.md
+++ b/content/part-03/sre-error-budgets/slides.md
@@ -1,0 +1,33 @@
+---
+marp: true
+title: SRE Error Budgets & Service Level Objectives
+---
+
+# Error Budgets & SLOs
+*Balancing reliability and feature velocity*
+
+---
+
+## Service level objectives
+- Define target reliability percentages
+- Measure user-facing performance
+- Clarify what "good enough" looks like
+
+---
+
+## Error budgets
+- Difference between perfect reliability and the SLO
+- Consumed as incidents and downtime occur
+- Helps prioritize fixes vs new features
+
+---
+
+## Using error budgets
+- Track burn rate over time
+- Slow releases when the budget runs low
+- Foster data-driven reliability conversations
+
+---
+
+## Key takeaway
+Error budgets turn SLOs into actionable limits on risk, guiding when to push forward or stabilize.


### PR DESCRIPTION
## Summary
- add slides & narratives for CI/CD pipeline design
- mark TODO item as complete

## Testing
- `go test ./...`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6871c475bc548325b1e7aa062e45fd9a