### PR TITLE
Add slides on post‑mortem communications

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -66,7 +66,7 @@ Use the checklist below to track progress for each part.
  - [x] Draft slides and narrative: Tracking improvement through deployment metrics and incident trends
  - [x] Draft slides and narrative: Typical post-mortem agenda, attendee roles and documentation standards
  - [x] Draft slides and narrative: Managing emotions and cultural barriers to blameless discussions
- - [ ] Draft slides and narrative: Communicating outcomes and tracking action items for accountability
+ - [x] Draft slides and narrative: Communicating outcomes and tracking action items for accountability
  - [ ] Draft slides and narrative: Alert correlation and incident timeline reconstruction techniques
  - [ ] Draft slides and narrative: Log analysis methods and using Git blame constructively
  - [ ] Draft slides and narrative: Metrics to monitor: MTTR trends, recurrence rates and action item completion

--- a/content/part-04/communicating-outcomes/narratives/01-intro.md
+++ b/content/part-04/communicating-outcomes/narratives/01-intro.md
@@ -1,0 +1,3 @@
+Speaker 1: After the dust settles on a major outage, it's tempting to move on quickly.
+Speaker 2: But unless we broadcast what happened and what we're doing about it, the same issues come back to haunt us.
+Speaker 1: This segment explains how sharing post-mortem results keeps everyone on the same page and sets the stage for real improvement.

--- a/content/part-04/communicating-outcomes/narratives/01-intro.md
+++ b/content/part-04/communicating-outcomes/narratives/01-intro.md
@@ -1,3 +1,4 @@
-Speaker 1: After the dust settles on a major outage, it's tempting to move on quickly.
-Speaker 2: But unless we broadcast what happened and what we're doing about it, the same issues come back to haunt us.
-Speaker 1: This segment explains how sharing post-mortem results keeps everyone on the same page and sets the stage for real improvement.
+Speaker 1: Once the dust finally settles—hopefully not literally falling from the ceiling onto your keyboard—it's tempting to simply move on.
+Speaker 2: We all want to forget the chaos, but if we don't discuss what happened, those same mistakes sneak back up on us.
+Speaker 1: This segment walks through why sharing the post-mortem results matters, how to keep different teams in the loop, and a few ways to make updates stick.
+Speaker 2: Think of it as sweeping up the debris, labeling the bags, and setting them out so everyone can recycle the lessons. Plus, a little openness keeps future dust from piling up again.

--- a/content/part-04/communicating-outcomes/narratives/02-share-outcomes.md
+++ b/content/part-04/communicating-outcomes/narratives/02-share-outcomes.md
@@ -1,0 +1,3 @@
+Speaker 1: Start with a plain-language summary—what failed, why and how you fixed it.
+Speaker 2: Link to the detailed post-mortem document so anyone can dig deeper.
+Speaker 1: Sharing this recap across teams spreads lessons learned and builds trust that issues are being handled.

--- a/content/part-04/communicating-outcomes/narratives/02-share-outcomes.md
+++ b/content/part-04/communicating-outcomes/narratives/02-share-outcomes.md
@@ -1,3 +1,5 @@
-Speaker 1: Start with a plain-language summary—what failed, why and how you fixed it.
-Speaker 2: Link to the detailed post-mortem document so anyone can dig deeper.
-Speaker 1: Sharing this recap across teams spreads lessons learned and builds trust that issues are being handled.
+Speaker 1: The first message after a major incident should be short and clear. Think "Our database server went down at 1 pm, we restored service by 2 pm, here's what happened."
+Speaker 2: Attach or link to the post-mortem document so anyone who needs the gritty details can read them later.
+Speaker 1: Send a similar summary to leadership, but highlight the business impact, such as how many users were affected, and outline next steps.
+Speaker 2: For customers or non-technical audiences, focus on reassurance—we're monitoring closely and will share updates each week until all fixes are deployed.
+Speaker 1: Sharing in different channels—email, Slack, or a status page—keeps everyone aligned and sets expectations for follow-ups.

--- a/content/part-04/communicating-outcomes/narratives/03-track-items.md
+++ b/content/part-04/communicating-outcomes/narratives/03-track-items.md
@@ -1,0 +1,3 @@
+Speaker 1: Every action item should have a single owner and a due date.
+Speaker 2: Logging it in ServiceNow or a GitHub issue keeps the task visible and prevents it from slipping through the cracks.
+Speaker 1: Bring these items to daily stand-ups so blockers get removed quickly.

--- a/content/part-04/communicating-outcomes/narratives/03-track-items.md
+++ b/content/part-04/communicating-outcomes/narratives/03-track-items.md
@@ -1,3 +1,5 @@
-Speaker 1: Every action item should have a single owner and a due date.
-Speaker 2: Logging it in ServiceNow or a GitHub issue keeps the task visible and prevents it from slipping through the cracks.
-Speaker 1: Bring these items to daily stand-ups so blockers get removed quickly.
+Speaker 1: Once a post-mortem wraps, every action item needs a single owner and a real deadline.
+Speaker 2: Stick it in ServiceNow or a GitHub issue—somewhere visible—so it can't quietly tumble down a crack in the floor.
+Speaker 1: A good ticket includes the action description, an assignee and the target date, like [OUT-123] Update database config – Owner: Lee, Due: 2025-08-01.
+Speaker 2: Bring these items to daily stand-ups or weekly meetings. If progress stalls for a week, escalate early.
+Speaker 1: Cross each item off as it's completed, then pat yourself on the back before the next one tries to slip away. It's amazing how slippery those tasks can be.

--- a/content/part-04/communicating-outcomes/narratives/04-close-loop.md
+++ b/content/part-04/communicating-outcomes/narratives/04-close-loop.md
@@ -1,0 +1,3 @@
+Speaker 1: Communication doesn't end once the meeting is over.
+Speaker 2: Post updates in the same ticket or chat thread so there's a single place to see progress.
+Speaker 1: At the next post-mortem, quickly review any unfinished items and highlight improvements backed by metrics.

--- a/content/part-04/communicating-outcomes/narratives/04-close-loop.md
+++ b/content/part-04/communicating-outcomes/narratives/04-close-loop.md
@@ -1,3 +1,5 @@
-Speaker 1: Communication doesn't end once the meeting is over.
-Speaker 2: Post updates in the same ticket or chat thread so there's a single place to see progress.
-Speaker 1: At the next post-mortem, quickly review any unfinished items and highlight improvements backed by metrics.
+Speaker 1: Communication doesn't end once the meeting wraps up.
+Speaker 2: Keep posting updates in the same ticket or chat thread so there's a single place to see progress.
+Speaker 1: When a fix is deployed, share a quick note such as: "Patch deployed to production at 22:00 UTC. Monitoring looks good."
+Speaker 2: At the next post-mortem or weekly review, run through any unfinished items and highlight improvements backed by metrics.
+Speaker 1: If tasks stall, escalate or reassign them so they don't linger forever. Closing the loop shows you're serious about follow-through and prevents lingering action items from becoming new incidents. A quick thank-you also goes a long way in keeping momentum high.

--- a/content/part-04/communicating-outcomes/narratives/05-takeaway.md
+++ b/content/part-04/communicating-outcomes/narratives/05-takeaway.md
@@ -1,2 +1,6 @@
-Speaker 1: When everyone knows the outcome and who's responsible for follow-up, improvements actually stick.
-Speaker 2: Documenting and revisiting action items demonstrates professionalism and builds confidence in the process.
+Speaker 1: When everyone knows the outcome and who's responsible for each fix, those improvements actually stick.
+Speaker 2: Documenting the steps in a shared place and checking back on them shows professionalism and builds confidence in the process.
+Speaker 1: It also prevents the dreaded "So whatever happened with that outage?" question from upper management.
+Speaker 2: Remind owners about upcoming deadlines and escalate only when absolutely necessary—a friendly nudge usually does the trick.
+Speaker 1: Open communication turns an unpleasant incident into an opportunity to improve and keeps you from repeating history.
+Speaker 2: Soon you'll have a track record of completing action items, which is the best proof that the post-mortem process works. So keep sharing updates, celebrate completed tasks and watch the trust in your team grow.

--- a/content/part-04/communicating-outcomes/narratives/05-takeaway.md
+++ b/content/part-04/communicating-outcomes/narratives/05-takeaway.md
@@ -1,0 +1,2 @@
+Speaker 1: When everyone knows the outcome and who's responsible for follow-up, improvements actually stick.
+Speaker 2: Documenting and revisiting action items demonstrates professionalism and builds confidence in the process.

--- a/content/part-04/communicating-outcomes/slides.md
+++ b/content/part-04/communicating-outcomes/slides.md
@@ -9,28 +9,80 @@ title: Communicating Outcomes
 ---
 
 ## Why share outcomes?
-- Summarise what happened and the fixes
-- Distribute lessons learned across teams
-- Link to detailed post-mortem notes
-- Keeps everyone aligned on next steps
+- Build trust by showing incidents are taken seriously and systematically addressed
+- Prevent repeats across teams by openly sharing root causes and fixes
+- Demonstrate accountability with owners and deadlines for each action item
+- Create an organizational memory of lessons learned for future reference
+- Meet compliance requirements such as ISO 27001 follow-up evidence
+- **Example:** After a database outage affecting 10k users, a summary email helped other teams spot similar risks in their own systems
+- Make the business impact clear so leaders can prioritise investments
+- Candid details build credibility even if everything isn't perfect
+
+---
+
+## Communication timing and audiences
+- Send an initial summary within 24 hours to leadership and directly impacted teams
+- Follow up weekly until all high-priority actions are closed
+- Tailor messaging: leadership wants business impact and timelines, technical staff need root cause details, customers need reassurance and next steps
+- Use dashboards or status pages for company-wide updates
+- Keep a single thread in Slack or Teams for ongoing questions
+- Reserve sensitive technical notes for internal docs and keep public messages short
+- Set expectations early by outlining major milestones and when each update will arrive
+- Invite questions so you can address them in subsequent follow-ups
 
 ---
 
 ## Track each action item
-- Assign a clear owner and due date
-- Record in ServiceNow or GitHub issues
-- Review progress in stand-ups
-- Escalate blockers early
+- Assign one owner and a clear due date so nothing gets lost
+- Capture items in a ticketing system like ServiceNow or GitHub
+- **Example ticket:** `[OUT-123] Update database configuration – Owner: Lee, Due: 2025‑08‑01`
+- Review progress in stand-ups and team meetings
+- Escalate to management when an item misses its deadline or stalls for a week
+- Write specific descriptions like "upgrade library X to version Y" rather than vague phrases
+- Link to relevant documentation or runbooks for more context
+- Check off each action when complete so progress stays visible
+- When new tasks emerge during remediation, create follow-up tickets right away
+
+---
+
+## Template examples
+- **Email:** "Team, our post‑mortem identified three fixes. See the attached doc for details. Jane owns the first, due Friday."
+- **Slack:** "Heads up: database patch rolling out tonight. Track progress in #incident‑123."
+- **Dashboard update:** Add a section summarizing closed and open items from recent incidents
+- Short, consistent templates make it easy for anyone to share updates without reinventing the wheel
+- A one-page summary template captures the incident, root cause, owners and due dates
+- Use a Slack snippet like `/incident update` to auto-fill your status channel
+- Maintain a wiki page with a table of updates for longer-running work
+- A simple table of item, owner, due date and status makes progress clear at a glance
+- Using the same structure across teams reduces confusion and speeds up handoffs
 
 ---
 
 ## Close the loop
-- Post updates in chat or email
-- Note completed actions in the ticket
-- Revisit outstanding items at the next post-mortem
-- Show improvements with metrics
+- Post updates in the original ticket or chat thread so everyone sees progress
+- **Example update:** "Patch deployed to production at 22:00 UTC. Monitoring shows no errors."
+- Note completed actions directly in the tracking system to keep records tidy
+- Revisit outstanding items at the next post-mortem and highlight improvements using metrics
+- When tasks drag on, call out the delay and reassign resources if needed
+- Celebrate completions with a quick thank-you to keep momentum going
+- Final message example: "Thanks for everyone's help—OUT-123 and OUT-124 are now closed."
+- Schedule a quick check-in a month later to confirm the fixes are holding
+- If open items stall, remind the team why they matter and escalate to leadership
+
+---
+
+## Metrics and success measures
+- Track completion rate of action items over time to show improvement
+- Monitor recurrence of similar incidents to gauge effectiveness of fixes
+- Report average time from incident to final follow‑up
+- Display these stats on team dashboards or monthly review meetings
+- Measuring progress keeps everyone honest and celebrates wins when numbers trend in the right direction
+- Compare current metrics with past baselines to prove communication efforts are paying off
+- Include graphs of MTTR trends to highlight faster recovery
+- Track how many updates were sent for each incident to gauge responsiveness
+- Share success stories when metrics improve to motivate the team
 
 ---
 
 ## Key takeaway
-Clear communication and follow-up turn insights into real progress.
+Clear, timely communication and thorough follow‑up turn insights into real progress and demonstrate professionalism.

--- a/content/part-04/communicating-outcomes/slides.md
+++ b/content/part-04/communicating-outcomes/slides.md
@@ -1,0 +1,36 @@
+---
+marp: true
+title: Communicating Outcomes
+---
+
+# Communicating Outcomes
+*Tracking action items for accountability*
+
+---
+
+## Why share outcomes?
+- Summarise what happened and the fixes
+- Distribute lessons learned across teams
+- Link to detailed post-mortem notes
+- Keeps everyone aligned on next steps
+
+---
+
+## Track each action item
+- Assign a clear owner and due date
+- Record in ServiceNow or GitHub issues
+- Review progress in stand-ups
+- Escalate blockers early
+
+---
+
+## Close the loop
+- Post updates in chat or email
+- Note completed actions in the ticket
+- Revisit outstanding items at the next post-mortem
+- Show improvements with metrics
+
+---
+
+## Key takeaway
+Clear communication and follow-up turn insights into real progress.


### PR DESCRIPTION
## Summary
- create `communicating-outcomes` module with slides and narratives
- mark the associated task in TODO as complete

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687e426db5748325bba7617b0ece8878