### PR TITLE
Expand vendor risk management slides

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -79,7 +79,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Vendor evaluation criteria and selection processes
   - [x] Draft slides and narrative: Contract negotiation basics covering SLA terms, pricing models and exit clauses
   - [x] Draft slides and narrative: Risk management: vendor lock-in, data security and business continuity planning
-  - [ ] Draft slides and narrative: Communication protocols for regular check-ins, escalation and reporting cadence
+  - [x] Draft slides and narrative: Communication protocols for regular check-ins, escalation and reporting cadence
   - [ ] Draft slides and narrative: Performance monitoring beyond renewals: service quality KPIs and improvement actions
   - [ ] Draft slides and narrative: Cost optimisation strategies including usage analysis and contract renegotiation timing
   - [ ] Draft slides and narrative: The vendor engagement funnel and MSP service hand-over points

--- a/TODO.md
+++ b/TODO.md
@@ -78,7 +78,7 @@ Use the checklist below to track progress for each part.
 - [x] Create to-do list items for each topic to draft slides and write narratives
   - [x] Draft slides and narrative: Vendor evaluation criteria and selection processes
   - [x] Draft slides and narrative: Contract negotiation basics covering SLA terms, pricing models and exit clauses
-  - [ ] Draft slides and narrative: Risk management: vendor lock-in, data security and business continuity planning
+  - [x] Draft slides and narrative: Risk management: vendor lock-in, data security and business continuity planning
   - [ ] Draft slides and narrative: Communication protocols for regular check-ins, escalation and reporting cadence
   - [ ] Draft slides and narrative: Performance monitoring beyond renewals: service quality KPIs and improvement actions
   - [ ] Draft slides and narrative: Cost optimisation strategies including usage analysis and contract renegotiation timing

--- a/TODO.md
+++ b/TODO.md
@@ -80,7 +80,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Contract negotiation basics covering SLA terms, pricing models and exit clauses
   - [x] Draft slides and narrative: Risk management: vendor lock-in, data security and business continuity planning
   - [x] Draft slides and narrative: Communication protocols for regular check-ins, escalation and reporting cadence
-  - [ ] Draft slides and narrative: Performance monitoring beyond renewals: service quality KPIs and improvement actions
+  - [x] Draft slides and narrative: Performance monitoring beyond renewals: service quality KPIs and improvement actions
   - [ ] Draft slides and narrative: Cost optimisation strategies including usage analysis and contract renegotiation timing
   - [ ] Draft slides and narrative: The vendor engagement funnel and MSP service hand-over points
   - [ ] Draft slides and narrative: Challenger Sales mindset with BANT and MEDDIC qualification frameworks

--- a/content/part-05/communication-protocols/narratives/01-intro.md
+++ b/content/part-05/communication-protocols/narratives/01-intro.md
@@ -1,0 +1,5 @@
+Speaker 1: Communication is the oil that keeps vendor relationships running smoothly.
+Speaker 2: Right, without a plan those check-in calls either never happen or spiral into unproductive chats.
+Speaker 1: Setting expectations early prevents scrambling later when an incident hits.
+Speaker 2: We'll cover how to schedule regular meetings, when to escalate and what reports to exchange so everyone's in the loop.
+Speaker 1: With a bit of structure you spend less time chasing updates and more time actually solving problems.

--- a/content/part-05/communication-protocols/narratives/02-check-ins.md
+++ b/content/part-05/communication-protocols/narratives/02-check-ins.md
@@ -1,0 +1,5 @@
+Speaker 1: Regular check-ins keep projects aligned as priorities shift.
+Speaker 2: I like setting a recurring calendar invite so nobody forgets. Share an agenda ahead of time so the call stays focused.
+Speaker 1: Review metrics and open action items, then flag any roadblocks coming up.
+Speaker 2: Even a brief weekly sync helps catch small issues before they turn into crises.
+Speaker 1: Think of it as routine maintenance for the partnership.

--- a/content/part-05/communication-protocols/narratives/03-escalation.md
+++ b/content/part-05/communication-protocols/narratives/03-escalation.md
@@ -1,0 +1,5 @@
+Speaker 1: Escalation paths map out who to call when something goes wrong.
+Speaker 2: Without them, you end up in voicemail jail while the outage drags on.
+Speaker 1: Define levels of severity and the expected response time for each.
+Speaker 2: Make sure both sides know the direct line to a manager if the normal channel fails.
+Speaker 1: Clear paths mean faster resolutions and less finger pointing.

--- a/content/part-05/communication-protocols/narratives/04-reporting.md
+++ b/content/part-05/communication-protocols/narratives/04-reporting.md
@@ -1,0 +1,5 @@
+Speaker 1: Reporting cadence keeps everyone accountable.
+Speaker 2: Monthly performance summaries show if service levels are slipping.
+Speaker 1: Incident reports within a day help us learn what went wrong and how to prevent repeats.
+Speaker 2: Quarterly reviews give space to adjust long-term plans or budgets.
+Speaker 1: Frequent but predictable updates stop surprises from derailing projects.

--- a/content/part-05/communication-protocols/narratives/05-takeaway.md
+++ b/content/part-05/communication-protocols/narratives/05-takeaway.md
@@ -1,0 +1,4 @@
+Speaker 1: Structured communication may feel formal, but it saves headaches later.
+Speaker 2: When everyone knows the schedule and who to call, problems get solved quickly.
+Speaker 1: So set up your meetings, document escalation contacts and keep sharing reports.
+Speaker 2: Do that and your vendor relationships will run a lot smoother.

--- a/content/part-05/communication-protocols/slides.md
+++ b/content/part-05/communication-protocols/slides.md
@@ -1,0 +1,45 @@
+---
+marp: true
+title: Vendor Communication Protocols
+---
+
+# Communication Protocols
+*Keeping vendors in sync*
+
+---
+
+## Why establish protocols?
+
+Regular communication prevents misunderstandings and surfaces issues early. Clear expectations reduce friction when priorities shift or problems arise. Setting protocols upfront tells everyone who to contact and when. Without structure, updates happen randomly and serious concerns may get buried. Simple guidelines—like who runs meetings and how often reports are shared—keep the relationship healthy and ensure both sides know what success looks like.
+
+---
+
+## Regular check-ins
+
+- Schedule weekly or monthly calls depending on service criticality
+- Share agendas beforehand and track action items
+- Use these sessions to review metrics, roadmap changes and upcoming risks
+
+---
+
+## Escalation paths
+
+- Define primary contacts and backups at both companies
+- Document severity levels and response times
+- Provide a direct line to management for urgent issues
+
+---
+
+## Reporting cadence
+
+- Monthly performance summaries and quarterly strategy reviews
+- Incident reports within 24 hours of outages
+- Periodic satisfaction surveys to adjust course
+
+---
+
+## Key takeaway
+
+Consistent communication builds trust and keeps projects on track.
+
+---

--- a/content/part-05/communication-protocols/slides.md
+++ b/content/part-05/communication-protocols/slides.md
@@ -10,7 +10,7 @@ title: Vendor Communication Protocols
 
 ## Why establish protocols?
 
-Regular communication prevents misunderstandings and surfaces issues early. Clear expectations reduce friction when priorities shift or problems arise. Setting protocols upfront tells everyone who to contact and when. Without structure, updates happen randomly and serious concerns may get buried. Simple guidelines—like who runs meetings and how often reports are shared—keep the relationship healthy and ensure both sides know what success looks like.
+Regular communication prevents misunderstandings and surfaces issues early. Clear expectations reduce friction when priorities shift or problems arise. For example, if a cloud outage hits overnight, a defined escalation list ensures the right engineers are paged instead of a frantic email chain. Setting protocols upfront tells everyone who to contact and when. Without structure, updates happen randomly and serious concerns may get buried. Simple guidelines—like who runs meetings and how often reports are shared—keep the relationship healthy and ensure both sides know what success looks like.
 
 ---
 
@@ -18,7 +18,8 @@ Regular communication prevents misunderstandings and surfaces issues early. Clea
 
 - Schedule weekly or monthly calls depending on service criticality
 - Share agendas beforehand and track action items
-- Use these sessions to review metrics, roadmap changes and upcoming risks
+- Review ticket metrics, upcoming releases and potential risks
+- Allocate time for roadblocks or resource requests
 
 ---
 
@@ -40,6 +41,6 @@ Regular communication prevents misunderstandings and surfaces issues early. Clea
 
 ## Key takeaway
 
-Consistent communication builds trust and keeps projects on track.
+Consistent communication builds trust, keeps projects on track and provides metrics to gauge vendor responsiveness and issue resolution.
 
 ---

--- a/content/part-05/performance-monitoring/narratives/01-intro.md
+++ b/content/part-05/performance-monitoring/narratives/01-intro.md
@@ -1,0 +1,4 @@
+Speaker 1: Welcome to our discussion on monitoring vendor performance long after the contract is signed. Many organisations breathe a sigh of relief once a solution goes live and forget to keep score.
+Speaker 2: But that's when subtle issues creep in. Maybe support response times stretch out or promised features remain half baked. Without metrics you might not notice until renewal is looming.
+Speaker 1: We'll explore the key indicators worth tracking and how to turn those numbers into real improvements. Think of it as a health check for your vendor relationships.
+Speaker 2: Let's dive into why ongoing monitoring matters.

--- a/content/part-05/performance-monitoring/narratives/02-why-monitor.md
+++ b/content/part-05/performance-monitoring/narratives/02-why-monitor.md
@@ -1,0 +1,4 @@
+Speaker 1: After onboarding, vendors sometimes settle into autopilot. Issues get triaged slower and the original enthusiasm fades.
+Speaker 2: Monitoring gives you evidence of that drift. For example, if average ticket resolution time climbs month over month, you can challenge the vendor before the decline becomes normal.
+Speaker 1: It's also leverage for negotiations. When renewal time comes, you want hard numbers showing whether service levels were met.
+Speaker 2: Continuous monitoring keeps both sides honest and ensures you spot trends early rather than scrambling during contract talks.

--- a/content/part-05/performance-monitoring/narratives/03-kpis.md
+++ b/content/part-05/performance-monitoring/narratives/03-kpis.md
@@ -1,0 +1,4 @@
+Speaker 1: So what should we measure? Start with the basics: how quickly the vendor responds and resolves support tickets, and how often the service goes down.
+Speaker 2: Include accuracy metrics too. If releases regularly break integrations, that's a red flag.
+Speaker 1: Customer satisfaction surveys reveal whether users feel supported. Adoption rates also matter because an unused feature provides no value even if it works perfectly.
+Speaker 2: Combine these metrics for a holistic view of quality rather than focusing on a single number.

--- a/content/part-05/performance-monitoring/narratives/04-improvement.md
+++ b/content/part-05/performance-monitoring/narratives/04-improvement.md
@@ -1,0 +1,4 @@
+Speaker 1: Numbers don't mean much unless you act on them. Schedule regular reviews with your vendor to discuss trends.
+Speaker 2: Bring a short list of the worst metrics and ask what they're doing about them. Maybe a spike in outages points to hardware upgrades or more training.
+Speaker 1: Assign owners for each action item so it doesn't vanish into thin air. Then check progress at the next meeting.
+Speaker 2: Over time these small improvements compound into significant service gains, proving the monitoring effort is worthwhile.

--- a/content/part-05/performance-monitoring/narratives/05-takeaway.md
+++ b/content/part-05/performance-monitoring/narratives/05-takeaway.md
@@ -1,0 +1,5 @@
+Speaker 1: The main point is simple—measure continuously and act on what you learn.
+Speaker 2: Keep a dashboard of KPIs handy so you can spot trends early. Share it with your vendor and agree on goals for improvement.
+Speaker 1: When renewal rolls around, those numbers will guide your negotiation strategy and highlight success stories.
+Speaker 1: Think of the metrics as your map; without them, you're just guessing where to go next.
+Speaker 2: Ongoing performance tracking turns a one-time purchase into a living partnership that evolves with your needs.

--- a/content/part-05/performance-monitoring/slides.md
+++ b/content/part-05/performance-monitoring/slides.md
@@ -1,0 +1,39 @@
+---
+marp: true
+title: Service Performance Monitoring
+---
+
+# Service Performance Monitoring
+*Staying proactive after go-live*
+
+---
+
+## Why watch metrics beyond renewals?
+
+Even after the ink dries on a contract, you need visibility into how well the vendor performs day to day. Service quality can drift over time as priorities change or teams turn over. Monitoring keeps small problems from becoming chronic frustrations. For instance, a help desk might respond quickly during onboarding but grow slower once the vendor has your business locked in. Tracking trends shows whether promised service levels still hold true a year later. Ultimately, performance monitoring gives you data to negotiate improvements rather than relying on vague impressions.
+
+---
+
+## Service quality KPIs
+
+- Response and resolution times for support tickets
+- Percentage of uptime and outage duration
+- Accuracy of change or release deployments
+- Customer satisfaction surveys and Net Promoter Scores
+- Adoption or usage rates for key features
+
+---
+
+## Turning insights into actions
+
+Collecting KPIs is just the start. Regularly review the numbers with your vendor and agree on improvement plans. Maybe recurring outages show the need for extra capacity, or survey feedback suggests better documentation. Document the action items, assign owners and follow up next review. An ongoing feedback loop turns raw metrics into tangible service upgrades and helps justify renewal decisions.
+
+---
+
+## Key takeaway
+
+- Track KPIs continuously, not just at renewal time
+- Review results jointly and set improvement targets
+- Use data trends to drive conversations on service quality
+
+---

--- a/content/part-05/risk-management/narratives/01-intro.md
+++ b/content/part-05/risk-management/narratives/01-intro.md
@@ -1,0 +1,11 @@
+Speaker 1: Vendors make bold promises, but what happens when they change
+pricing or disappear entirely? If your whole service depends on them, even a
+minor hiccup can snowball into a major disruption.
+Speaker 2: Exactly. Risk management is about preparing for those "what if"
+moments before they happen so you're not left scrambling. We'll break down
+vendor lock-in, data security, business continuity and a few other gotchas that
+often get overlooked.
+Speaker 1: Think of it as disaster planning for external relationships. The more
+you understand potential pitfalls, the easier it is to negotiate contracts and
+set expectations from the start. Ready to dig in?
+Speaker 2: Let's do it.

--- a/content/part-05/risk-management/narratives/02-lock-in.md
+++ b/content/part-05/risk-management/narratives/02-lock-in.md
@@ -1,0 +1,11 @@
+Speaker 1: "Vendor lock-in" means it's painfully difficult to move your data or
+workflow somewhere else. Think about a car that only runs on fuel from one
+specific gas station chain.
+Speaker 2: The longer you rely on their proprietary format, the more trapped you
+become. I've seen companies spend six months and $50,000 just to migrate their
+customer databases to a new CRM.
+Speaker 1: That's why you negotiate export capabilities and reasonable notice
+periods up front. Ask to see an export demo during the sales process, not after
+you've signed a contract.
+Speaker 2: When switching is possible before you need to switch, you keep the
+power in the relationship instead of the vendor.

--- a/content/part-05/risk-management/narratives/03-data-security.md
+++ b/content/part-05/risk-management/narratives/03-data-security.md
@@ -1,5 +1,5 @@
 Speaker 1: When you hand over data to a vendor, it's like giving someone the keys to your house.
-Speaker 2: Right, you want to know exactly how many locks they use and who else has copies. Ask about encryption both at rest and in transit.
+Speaker 2: Right, and it's like a friend borrowing your car—you want to know they have insurance and won't lend it to their teenager. Ask about encryption both at rest and in transit.
 Speaker 1: Don't forget access controls. If anyone at the vendor can peek at your information, that's a problem.
 Speaker 2: A mature vendor will show you compliance certificates and walk you through their incident response plan. If they get hacked, how quickly will they tell you?
 Speaker 1: And check their history. A breach isn't always a deal breaker, but silence or slow notifications definitely are.

--- a/content/part-05/risk-management/narratives/03-data-security.md
+++ b/content/part-05/risk-management/narratives/03-data-security.md
@@ -1,0 +1,5 @@
+Speaker 1: When you hand over data to a vendor, it's like giving someone the keys to your house.
+Speaker 2: Right, you want to know exactly how many locks they use and who else has copies. Ask about encryption both at rest and in transit.
+Speaker 1: Don't forget access controls. If anyone at the vendor can peek at your information, that's a problem.
+Speaker 2: A mature vendor will show you compliance certificates and walk you through their incident response plan. If they get hacked, how quickly will they tell you?
+Speaker 1: And check their history. A breach isn't always a deal breaker, but silence or slow notifications definitely are.

--- a/content/part-05/risk-management/narratives/04-bcp.md
+++ b/content/part-05/risk-management/narratives/04-bcp.md
@@ -1,0 +1,5 @@
+Speaker 1: Business continuity is your lifeboat when a vendor hits rough seas.
+Speaker 2: Ask for proof that their backups actually work—a written plan is meaningless if they've never restored from it.
+Speaker 1: Some companies schedule practice runs where they simulate a complete outage and measure how quickly systems come back online. That's the kind of evidence you want.
+Speaker 2: Also think about dependencies. If your vendor goes down, do you have a secondary provider, or at least an exit clause that lets you bring operations in-house?
+Speaker 1: Having these options ahead of time turns a potential disaster into a temporary inconvenience.

--- a/content/part-05/risk-management/narratives/04-bcp.md
+++ b/content/part-05/risk-management/narratives/04-bcp.md
@@ -1,5 +1,5 @@
 Speaker 1: Business continuity is your lifeboat when a vendor hits rough seas.
-Speaker 2: Ask for proof that their backups actually work—a written plan is meaningless if they've never restored from it.
+Speaker 2: Backup plans are like fire drills—they only work if you've actually practiced them. Ask for proof that their backups actually work—a written plan is meaningless if they've never restored from it.
 Speaker 1: Some companies schedule practice runs where they simulate a complete outage and measure how quickly systems come back online. That's the kind of evidence you want.
 Speaker 2: Also think about dependencies. If your vendor goes down, do you have a secondary provider, or at least an exit clause that lets you bring operations in-house?
 Speaker 1: Having these options ahead of time turns a potential disaster into a temporary inconvenience.

--- a/content/part-05/risk-management/narratives/05-takeaway.md
+++ b/content/part-05/risk-management/narratives/05-takeaway.md
@@ -1,0 +1,5 @@
+Speaker 1: A well-crafted risk plan keeps surprises from derailing your overall strategy.
+Speaker 2: Exactly. When you've covered lock-in, security, continuity and finances, a vendor hiccup becomes an inconvenience instead of a crisis.
+Speaker 1: The time you invest early on saves countless hours later—and often a lot of money.
+Speaker 2: Keep reviewing your vendors annually. Markets shift, products evolve and new regulations pop up, so a "set and forget" approach won't cut it.
+Speaker 1: Staying proactive is the best insurance policy for long-term success.

--- a/content/part-05/risk-management/narratives/06-financial-risk.md
+++ b/content/part-05/risk-management/narratives/06-financial-risk.md
@@ -1,5 +1,5 @@
 Speaker 1: Hidden costs are often the biggest surprise with a new vendor.
-Speaker 2: Absolutely. Licensing tiers, data overage charges and currency swings can blow the budget fast.
-Speaker 1: I've seen startups lure customers with low introductory pricing, then double rates after a year when you're deeply integrated.
+Speaker 2: So what should we look out for in pricing structures? Licensing tiers, data overage charges and currency swings can blow the budget fast.
+Speaker 1: I've seen startups lure customers with low introductory pricing, then double rates after a year when you're deeply integrated. Per-seat licensing that seems cheap at ten users may balloon to fifty thousand dollars at five hundred.
 Speaker 2: That's why you model best- and worst-case scenarios before signing. Ask how renewals are calculated and whether discounts vanish if usage dips.
 Speaker 1: A solid financial assessment now prevents nasty surprises later and helps you decide whether a cheaper vendor actually costs more in the long run.

--- a/content/part-05/risk-management/narratives/06-financial-risk.md
+++ b/content/part-05/risk-management/narratives/06-financial-risk.md
@@ -1,0 +1,5 @@
+Speaker 1: Hidden costs are often the biggest surprise with a new vendor.
+Speaker 2: Absolutely. Licensing tiers, data overage charges and currency swings can blow the budget fast.
+Speaker 1: I've seen startups lure customers with low introductory pricing, then double rates after a year when you're deeply integrated.
+Speaker 2: That's why you model best- and worst-case scenarios before signing. Ask how renewals are calculated and whether discounts vanish if usage dips.
+Speaker 1: A solid financial assessment now prevents nasty surprises later and helps you decide whether a cheaper vendor actually costs more in the long run.

--- a/content/part-05/risk-management/narratives/07-operational-dependencies.md
+++ b/content/part-05/risk-management/narratives/07-operational-dependencies.md
@@ -1,0 +1,5 @@
+Speaker 1: Operational risk creeps in when one vendor becomes the single point of failure for your processes.
+Speaker 2: Think about how many teams rely on Slack or Teams for day-to-day work. When the service went down for hours in 2021, many companies had no backup communication plan.
+Speaker 1: Documenting alternative workflows and training staff on them keeps you from grinding to a halt if a tool goes offline.
+Speaker 2: Budget time for switching, too. If a new vendor requires retraining or rewriting integrations, include that effort in your planning.
+Speaker 1: Reducing dependency is about being ready to pivot before you're forced to.

--- a/content/part-05/risk-management/narratives/08-legal-compliance.md
+++ b/content/part-05/risk-management/narratives/08-legal-compliance.md
@@ -1,0 +1,5 @@
+Speaker 1: Legal risks often hide in the fine print of vendor agreements.
+Speaker 2: Data residency clauses, privacy regulations and industry-specific laws can limit where your information is stored or processed.
+Speaker 1: Ask vendors which compliance certifications they hold and whether they've ever failed an audit.
+Speaker 2: Also clarify liability. If they mishandle your data or violate regulations, who pays the fines or remediation costs?
+Speaker 1: Spending an hour with legal counsel now can save months of headaches and potential penalties later.

--- a/content/part-05/risk-management/narratives/08-legal-compliance.md
+++ b/content/part-05/risk-management/narratives/08-legal-compliance.md
@@ -2,4 +2,5 @@ Speaker 1: Legal risks often hide in the fine print of vendor agreements.
 Speaker 2: Data residency clauses, privacy regulations and industry-specific laws can limit where your information is stored or processed.
 Speaker 1: Ask vendors which compliance certifications they hold and whether they've ever failed an audit.
 Speaker 2: Also clarify liability. If they mishandle your data or violate regulations, who pays the fines or remediation costs?
-Speaker 1: Spending an hour with legal counsel now can save months of headaches and potential penalties later.
+Speaker 1: Compliance fatigue is real for small businesses, but skipping due diligence leaves you exposed.
+Speaker 2: To wrap up, confirm data location, certification status and liability provisions before you sign anything.

--- a/content/part-05/risk-management/slides.md
+++ b/content/part-05/risk-management/slides.md
@@ -61,7 +61,8 @@ sunny.
 - Factor in currency swings and automatic renewal clauses that increase fees annually.
 - Weigh the stability of startups versus established firms—one may cost less but carry higher risk.
 
-Case studies abound of companies spending hundreds of thousands migrating away from platforms that unexpectedly doubled their prices. A thorough financial review now prevents nasty surprises down the line.
+- Case study: one firm spent $200K migrating from Oracle to PostgreSQL after licensing fees spiked.
+- Thorough financial reviews early on prevent nasty surprises later.
 
 ---
 
@@ -101,11 +102,13 @@ Data sovereignty laws and industry regulations can dictate where and how vendor 
 
 ---
 
-## Key takeaway
+ ## Key takeaway
 
-- Ask about data export options before signing
-- Verify security certifications and test backups
-- Schedule regular reviews to keep risks visible
+ - Ask about data export options before signing
+ - Verify security certifications and test backups
+ - Schedule regular reviews to keep risks visible
+ - Document who owns each vendor relationship internally
+ - Hold a quarterly risk review to track emerging issues
 
 ---
 

--- a/content/part-05/risk-management/slides.md
+++ b/content/part-05/risk-management/slides.md
@@ -56,24 +56,56 @@ sunny.
 
 ## Financial risk assessment
 
-Technology budgets rarely stay static, and hidden vendor costs can wreck even the best-planned projects. Analyse licensing models carefully: is pricing based on users, data volume or something else entirely? Factor in currency fluctuations if you're paying in a foreign denomination, and watch out for automatic renewal clauses that increase fees each year. Startups may offer tempting discounts but could disappear before your contract ends, while large vendors might charge more but carry less financial risk. Case studies abound of companies spending hundreds of thousands migrating away from platforms that unexpectedly doubled their prices. A thorough financial review now prevents nasty surprises down the line.
+- Analyse licensing models carefully: is pricing based on users, data volume or something else entirely?
+- Watch for per-seat pricing that looks cheap at 10 users but explodes to $50K at 500.
+- Factor in currency swings and automatic renewal clauses that increase fees annually.
+- Weigh the stability of startups versus established firms—one may cost less but carry higher risk.
+
+Case studies abound of companies spending hundreds of thousands migrating away from platforms that unexpectedly doubled their prices. A thorough financial review now prevents nasty surprises down the line.
 
 ---
 
 ## Operational dependencies
 
-Relying on a single vendor can create a fragile chain of dependencies. If their service goes down, do your internal processes grind to a halt? Consider how long it would take staff to learn a replacement system or rebuild integrations. A real-world outage, like Slack's six-hour downtime in 2021, left many teams scrambling because chatbots and help desks all flowed through a single tool. Document alternative workflows and build training time into your budget so switching providers doesn't paralyse your organisation.
+Relying on a single vendor can create a fragile chain of dependencies. If their service goes down, do your internal processes grind to a halt? Consider how long it would take staff to learn a replacement system or rebuild integrations. A real-world outage, like Slack's six-hour downtime in 2021, left many teams scrambling because chatbots and help desks all flowed through a single tool. Document alternative workflows—when Slack is down, teams might revert to email threads and phone trees—and build training time into your budget so switching providers doesn't paralyse your organisation.
 
 ---
 
 ## Legal and compliance considerations
 
-Data sovereignty laws and industry regulations can dictate where and how vendor services operate. Ensure that contracts spell out who owns the data, how it may be used and what liability the vendor carries if they breach privacy or security requirements. Ask about compliance certifications relevant to your sector, such as HIPAA for health data or PCI DSS for payment processing. Some jurisdictions require your data to remain in-country, so confirm server locations and backup storage. Insurance coverage and indemnity clauses also play a role; they define who pays if things go wrong. Understanding these legal obligations up front reduces headaches later.
+Data sovereignty laws and industry regulations can dictate where and how vendor services operate. Ensure that contracts spell out who owns the data, how it may be used and what liability the vendor carries if they breach privacy or security requirements. Ask about compliance certifications relevant to your sector. For example, healthcare providers must verify HIPAA compliance before putting records in the cloud, while retailers may need PCI DSS for payment details. Some jurisdictions require your data to remain in-country, so confirm server locations and backup storage. Insurance coverage and indemnity clauses also play a role; they define who pays if things go wrong. Understanding these legal obligations up front reduces headaches later.
+
+---
+
+## Due diligence checklist
+
+- Evaluate financial stability and customer references
+- Review security certifications and audit reports
+- Test data export options before signing
+
+---
+
+## Red flags during selection
+
+- Evasive answers about pricing or compliance
+- No references or vague case studies
+- Unrealistic implementation timelines
+
+---
+
+## Exit strategy planning
+
+- Negotiate clear termination clauses and notice periods
+- Document data migration steps and associated costs
+- Keep alternative vendors in mind in case you need to switch
 
 ---
 
 ## Key takeaway
-Proactive risk planning keeps you in control if a vendor fails.
+
+- Ask about data export options before signing
+- Verify security certifications and test backups
+- Schedule regular reviews to keep risks visible
 
 ---
 

--- a/content/part-05/risk-management/slides.md
+++ b/content/part-05/risk-management/slides.md
@@ -1,0 +1,79 @@
+---
+marp: true
+title: Vendor Risk Management
+---
+
+# Vendor Risk Management
+*Protecting continuity and security*
+
+---
+
+## Why worry about vendor lock-in?
+
+Vendor lock-in happens when switching away from a service becomes expensive or 
+technically difficult. Imagine all your files saved in a format that only one
+vendor's software understands. Changing providers might require costly data
+conversions or lengthy downtime, so the vendor holds all the power. Real-world
+examples range from custom Salesforce integrations that won't export cleanly to
+cloud platforms with no easy migration path. Warning signs include contracts
+with 12‑month notice periods, proprietary data formats, or ongoing integration
+fees that grow over time. It's like dating someone who slowly moves all your
+stuff to their place—leaving suddenly becomes a major project. Always ask,
+"How do we get our data out if we need to leave?" up front and negotiate
+reasonable exit clauses before signing anything.
+
+---
+
+## Safeguarding data security
+
+Handing over data to a vendor is like giving someone the keys to your house.
+You want to know their locks are strong and they actually monitor who comes and
+goes. Ask about encryption both in transit and at rest, and check whether staff
+undergo background checks before they can access your information. Find out
+where servers are located because privacy laws differ around the world. Don't be
+shy about their breach history—have they ever disclosed incidents and how long
+did notification take? A reputable vendor will gladly provide documentation such
+as SOC 2 or ISO 27001 certifications and will outline their incident response
+process. If they dodge questions or claim "trust us," that's a red flag. Asking
+about security shouldn't feel like interrogating a spy; if they're evasive,
+that's your answer right there.
+
+---
+
+## Business continuity planning
+
+Every vendor will claim they have backups, but have those backups ever been
+restored in a real emergency? Ask to see test results or drills where the vendor
+simulated a failure and recovered systems. Business continuity also means
+thinking beyond a single provider. Maintain a secondary supplier or at least a
+clear exit clause so you can pivot if their service goes dark. Map out
+escalation paths for different severities—who do you call if the service is down
+for an hour versus a day? Having a well‑practiced plan keeps you operating when
+surprises strike, just like carrying an umbrella even when the forecast looks
+sunny.
+
+---
+
+## Financial risk assessment
+
+Technology budgets rarely stay static, and hidden vendor costs can wreck even the best-planned projects. Analyse licensing models carefully: is pricing based on users, data volume or something else entirely? Factor in currency fluctuations if you're paying in a foreign denomination, and watch out for automatic renewal clauses that increase fees each year. Startups may offer tempting discounts but could disappear before your contract ends, while large vendors might charge more but carry less financial risk. Case studies abound of companies spending hundreds of thousands migrating away from platforms that unexpectedly doubled their prices. A thorough financial review now prevents nasty surprises down the line.
+
+---
+
+## Operational dependencies
+
+Relying on a single vendor can create a fragile chain of dependencies. If their service goes down, do your internal processes grind to a halt? Consider how long it would take staff to learn a replacement system or rebuild integrations. A real-world outage, like Slack's six-hour downtime in 2021, left many teams scrambling because chatbots and help desks all flowed through a single tool. Document alternative workflows and build training time into your budget so switching providers doesn't paralyse your organisation.
+
+---
+
+## Legal and compliance considerations
+
+Data sovereignty laws and industry regulations can dictate where and how vendor services operate. Ensure that contracts spell out who owns the data, how it may be used and what liability the vendor carries if they breach privacy or security requirements. Ask about compliance certifications relevant to your sector, such as HIPAA for health data or PCI DSS for payment processing. Some jurisdictions require your data to remain in-country, so confirm server locations and backup storage. Insurance coverage and indemnity clauses also play a role; they define who pays if things go wrong. Understanding these legal obligations up front reduces headaches later.
+
+---
+
+## Key takeaway
+Proactive risk planning keeps you in control if a vendor fails.
+
+---
+


### PR DESCRIPTION
## Summary
- expand risk management slides with detailed explanations and extra topics
- extend narrative scripts to ~100 words each
- add new narratives covering financial risk, operational dependencies and compliance
- keep risk management to-do entry completed

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688b0d86e6d88325a940c4aa6be2700a