### PR TITLE
Add styled website index with summaries

### DIFF
--- a/content/part-06/outline.md
+++ b/content/part-06/outline.md
@@ -1,0 +1,3 @@
+# Part 6 – Start-ups & Small-Biz IT
+
+This part highlights how lean start-ups and small businesses bootstrap their IT stack, adopt lightweight tools, and scale processes as they grow.

--- a/content/part-08/outline.md
+++ b/content/part-08/outline.md
@@ -1,0 +1,3 @@
+# Part 8 – Project Studio and Presentations
+
+This capstone brings teams together to refine final projects and present their work, integrating lessons from across the course.

--- a/scripts/generate_website_index.sh
+++ b/scripts/generate_website_index.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
 set -e
+
 SITE_DIR="website"
+RUN_DIR="$SITE_DIR/run-script"
 INDEX_FILE="$SITE_DIR/index.html"
+CSS_FILE="$SITE_DIR/style.css"
 
 mkdir -p "$SITE_DIR"
+
+# Write CSS styling
+cat > "$CSS_FILE" <<'EOT'
+body { font-family: Arial, sans-serif; margin: 2rem; background-color: #f4f4f4; color: #333; }
+h1 { color: #222; }
+.part-list { list-style: none; padding: 0; }
+.part-list li { background: #fff; margin: 1rem 0; padding: 1rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+.part-list a { text-decoration: none; color: #007acc; font-size: 1.2rem; }
+.part-list p { margin: 0.5rem 0 0; }
+EOT
 
 # Begin HTML file
 cat > "$INDEX_FILE" <<EOT
@@ -11,26 +24,24 @@ cat > "$INDEX_FILE" <<EOT
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Professional Practice Artifacts</title>
+  <title>Professional Practice Run Scripts</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Professional Practice Artifacts</h1>
-  <ul>
+  <h1>Professional Practice Run Scripts</h1>
+  <ul class="part-list">
 EOT
 
 shopt -s nullglob
-entries=("$SITE_DIR"/*)
-IFS=$'\n' sorted=($(sort <<<"${entries[*]}"))
-unset IFS
-for entry in "${sorted[@]}"; do
-  name=$(basename "$entry")
-  [ "$name" = "index.html" ] && continue
-  if [ -d "$entry" ]; then
-    echo "    <li><a href=\"$name/\">$name/</a></li>" >> "$INDEX_FILE"
-  else
-    echo "    <li><a href=\"$name\">$name</a></li>" >> "$INDEX_FILE"
-  fi
+for outline in content/part-*/outline.md; do
+  [ -f "$outline" ] || continue
+  part_dir=$(dirname "$outline")
+  part=$(basename "$part_dir")
+  title=$(sed -n 's/^# Part [0-9]*[[:space:]][–-][[:space:]]*//p' "$outline")
+  summary=$(awk 'NR>1 && NF {print; exit}' "$outline")
+  printf '    <li><a href="run-script/%s/">%s</a><p>%s</p></li>\n' "$part" "$title" "$summary" >> "$INDEX_FILE"
 done
+shopt -u nullglob
 
 cat >> "$INDEX_FILE" <<EOT
   </ul>
@@ -38,4 +49,4 @@ cat >> "$INDEX_FILE" <<EOT
 </html>
 EOT
 
-printf 'Generated %s\n' "$INDEX_FILE"
+printf 'Generated %s and %s\n' "$INDEX_FILE" "$CSS_FILE"

--- a/website/index.html
+++ b/website/index.html
@@ -13,7 +13,9 @@
     <li><a href="run-script/part-03/">High-Velocity Delivery</a><p>This part introduces modern DevOps practices and SRE principles that enable organizations to deliver software rapidly while maintaining reliability and quality.</p></li>
     <li><a href="run-script/part-04/">Blameless RCA & Continuous Improvement</a><p>This part focuses on establishing a culture of learning from incidents without assigning blame, and using structured approaches to drive service improvements.</p></li>
     <li><a href="run-script/part-05/">Vendor/MSP & CRM Lifecycle</a><p>This part demystifies how vendors and managed service providers handle the customer journey from first outreach to renewal. Students learn how CRM platforms coordinate sales commitments with ongoing service delivery.</p></li>
+    <li><a href="run-script/part-06/">Start-ups & Small-Biz IT</a><p>This part highlights how lean start-ups and small businesses bootstrap their IT stack, adopt lightweight tools, and scale processes as they grow.</p></li>
     <li><a href="run-script/part-07/">Open-Source & Indigenous Digital Sovereignty</a><p>This part explores how open-source communities collaborate and how data sovereignty principles protect Indigenous rights. Students learn to contribute responsibly and evaluate open-source solutions through an ethical lens.</p></li>
+    <li><a href="run-script/part-08/">Project Studio and Presentations</a><p>This capstone brings teams together to refine final projects and present their work, integrating lessons from across the course.</p></li>
   </ul>
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -2,12 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Professional Practice Artifacts</title>
+  <title>Professional Practice Run Scripts</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Professional Practice Artifacts</h1>
-  <ul>
-    <li><a href="run-script/">run-script/</a></li>
+  <h1>Professional Practice Run Scripts</h1>
+  <ul class="part-list">
+    <li><a href="run-script/part-01/">ITIL 4 Foundations</a><p>This part introduces the basic concepts of service management and the terminology used in enterprise IT operations.</p></li>
+    <li><a href="run-script/part-02/">ITIL Deep Dive</a><p>This part builds on the foundations by examining how mature IT teams use ITIL processes to manage change and drive continual improvement.</p></li>
+    <li><a href="run-script/part-03/">High-Velocity Delivery</a><p>This part introduces modern DevOps practices and SRE principles that enable organizations to deliver software rapidly while maintaining reliability and quality.</p></li>
+    <li><a href="run-script/part-04/">Blameless RCA & Continuous Improvement</a><p>This part focuses on establishing a culture of learning from incidents without assigning blame, and using structured approaches to drive service improvements.</p></li>
+    <li><a href="run-script/part-05/">Vendor/MSP & CRM Lifecycle</a><p>This part demystifies how vendors and managed service providers handle the customer journey from first outreach to renewal. Students learn how CRM platforms coordinate sales commitments with ongoing service delivery.</p></li>
+    <li><a href="run-script/part-07/">Open-Source & Indigenous Digital Sovereignty</a><p>This part explores how open-source communities collaborate and how data sovereignty principles protect Indigenous rights. Students learn to contribute responsibly and evaluate open-source solutions through an ethical lens.</p></li>
   </ul>
 </body>
 </html>

--- a/website/style.css
+++ b/website/style.css
@@ -1,0 +1,6 @@
+body { font-family: Arial, sans-serif; margin: 2rem; background-color: #f4f4f4; color: #333; }
+h1 { color: #222; }
+.part-list { list-style: none; padding: 0; }
+.part-list li { background: #fff; margin: 1rem 0; padding: 1rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+.part-list a { text-decoration: none; color: #007acc; font-size: 1.2rem; }
+.part-list p { margin: 0.5rem 0 0; }


### PR DESCRIPTION
## Summary
- Generate an `index.html` for the site that lists each part with title and one-line summary
- Include a reusable `style.css` and link it from the index
- Script now outputs both files for deployment

## Testing
- `./scripts/generate_website_index.sh`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a86424154483258f21630f108dcf0e