### PR TITLE
Add proof-of-concept management content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -85,7 +85,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: The vendor engagement funnel and MSP service hand-over points
   - [x] Draft slides and narrative: Challenger Sales mindset with BANT and MEDDIC qualification frameworks
   - [x] Draft slides and narrative: Discovery call techniques for surfacing pain points
-  - [ ] Draft slides and narrative: Proof-of-concept management and success criteria
+  - [x] Draft slides and narrative: Proof-of-concept management and success criteria
   - [ ] Draft slides and narrative: Competitive displacement strategies in crowded markets
   - [ ] Draft slides and narrative: CRM fundamentals using Salesforce Trailhead modules
   - [ ] Draft slides and narrative: Key economics in tech sales: ARR vs one-time deals and land-and-expand growth

--- a/content/part-05/proof-of-concept-management/narratives/01-intro.md
+++ b/content/part-05/proof-of-concept-management/narratives/01-intro.md
@@ -1,0 +1,4 @@
+Speaker 1: Jumping straight into production with a new tool can be risky.
+Speaker 2: That's why teams run a proof of concept—to test the waters before committing budget and resources.
+Speaker 1: The goal is to validate that the vendor can solve the problem and fit into existing workflows.
+Speaker 2: We'll walk through setting success criteria, keeping scope tight and evaluating results so POCs lead to clear decisions.

--- a/content/part-05/proof-of-concept-management/narratives/02-success-criteria.md
+++ b/content/part-05/proof-of-concept-management/narratives/02-success-criteria.md
@@ -1,0 +1,4 @@
+Speaker 1: Proofs of concept drift when success isn't defined.
+Speaker 2: Agree on measurable outcomes like response times or user satisfaction scores.
+Speaker 1: Set a short checklist of must-haves and nice-to-haves.
+Speaker 2: Document the baseline so you can compare results after the trial.

--- a/content/part-05/proof-of-concept-management/narratives/03-scope-timeline.md
+++ b/content/part-05/proof-of-concept-management/narratives/03-scope-timeline.md
@@ -1,0 +1,4 @@
+Speaker 1: Ever seen a two-week POC turn into a three-month mini-project?
+Speaker 2: To avoid that, keep the scope tight—limited users, datasets and integrations.
+Speaker 1: Assign a project lead and schedule regular check-ins.
+Speaker 2: Treat the POC like a sprint with a clear start and end date.

--- a/content/part-05/proof-of-concept-management/narratives/04-evaluate.md
+++ b/content/part-05/proof-of-concept-management/narratives/04-evaluate.md
@@ -1,0 +1,4 @@
+Speaker 1: When the trial ends, gather metrics and user feedback.
+Speaker 2: Compare the results against the success criteria you set.
+Speaker 1: Decide whether to proceed, adjust, or walk away.
+Speaker 2: Summarise the findings in a short report so stakeholders understand the recommendation.

--- a/content/part-05/proof-of-concept-management/narratives/05-takeaway.md
+++ b/content/part-05/proof-of-concept-management/narratives/05-takeaway.md
@@ -1,0 +1,4 @@
+Speaker 1: A disciplined proof of concept reduces risk and builds confidence.
+Speaker 2: Define success, control scope and evaluate honestly.
+Speaker 1: Then you can move forward with evidence or save money by walking away.
+Speaker 2: Either outcome beats committing blindly.

--- a/content/part-05/proof-of-concept-management/slides.md
+++ b/content/part-05/proof-of-concept-management/slides.md
@@ -1,0 +1,43 @@
+---
+marp: true
+title: Proof-of-Concept Management
+---
+
+# Proof-of-Concept Management
+*Testing ideas before full commitment*
+
+---
+
+## Why run a proof of concept?
+
+Running a small trial reduces risk before signing a long contract. Teams can validate functionality, integration and user fit without a full deployment. A short experiment uncovers deal‑breakers early and builds evidence to support or reject the vendor.
+
+---
+
+## Define success upfront
+
+- Agree on measurable outcomes like latency targets or user satisfaction.
+- Capture a baseline so improvements are clear.
+- Distinguish must‑have criteria from nice‑to‑have bonuses.
+
+---
+
+## Manage scope and timeline
+
+- Limit participants, datasets and integrations.
+- Assign a project lead and schedule regular check‑ins.
+- Treat the POC like a sprint with a clear start and end date.
+
+---
+
+## Evaluate and document outcomes
+
+Gather metrics and feedback at the end of the trial. Decide on go, no‑go or adjust and rerun. Share a brief report so leadership understands the recommendation and any follow‑up work.
+
+---
+
+## Key takeaway
+
+Disciplined POC management sets expectations, controls risk and provides evidence for investment decisions.
+
+---


### PR DESCRIPTION
## Summary
- add Part 5 slides for proof-of-concept management and success criteria
- include companion narratives explaining success metrics, scope control, and evaluation
- mark the task as complete in the to-do list

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab089ca2b88325b1131ad7930efdb7