### PR TITLE
Add usage-based pricing and churn prevention content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -89,7 +89,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Competitive displacement strategies in crowded markets
   - [x] Draft slides and narrative: CRM fundamentals using Salesforce Trailhead modules
   - [x] Draft slides and narrative: Key economics in tech sales: ARR vs one-time deals and land-and-expand growth
-  - [ ] Draft slides and narrative: Usage-based pricing models and churn prevention via customer health scoring
+  - [x] Draft slides and narrative: Usage-based pricing models and churn prevention via customer health scoring
   - [ ] Draft slides and narrative: How tech sales differs from other industries: recurring revenue models and rapid product cycles
   - [ ] Draft slides and narrative: Multi-stakeholder buying committees and long deal cycles in enterprise tech
   - [ ] Draft slides and narrative: Close alignment with product teams for solution selling and technical validation

--- a/content/part-05/usage-based-pricing/narratives/01-what-is-usage-based-pricing.md
+++ b/content/part-05/usage-based-pricing/narratives/01-what-is-usage-based-pricing.md
@@ -1,0 +1,4 @@
+Speaker 1: Picture paying for electricity. The bill goes up only if you leave the lights on all night.
+Speaker 2: Usage-based pricing works the same way for software. Customers are charged for what they actually consume.
+Speaker 1: That flexibility lowers the barrier to entry and invites teams to try a service without massive upfront licences.
+Speaker 2: And as their usage grows, revenue grows too, keeping the provider and customer in step.

--- a/content/part-05/usage-based-pricing/narratives/02-common-usage-metrics.md
+++ b/content/part-05/usage-based-pricing/narratives/02-common-usage-metrics.md
@@ -1,0 +1,4 @@
+Speaker 1: Measuring consumption isn't one size fits all.
+Speaker 2: An API platform might count calls, while a storage service tallies gigabytes saved.
+Speaker 1: Some SaaS tools track active seats each month or features enabled per user.
+Speaker 2: The key is choosing metrics that mirror the value customers get so invoices feel fair, not mysterious.

--- a/content/part-05/usage-based-pricing/narratives/03-benefits.md
+++ b/content/part-05/usage-based-pricing/narratives/03-benefits.md
@@ -1,0 +1,4 @@
+Speaker 1: When pricing tracks usage, smaller customers can start cheap and scale as they grow.
+Speaker 2: That reduces friction for sales teams—no need for huge discounts just to win a pilot.
+Speaker 1: Finance loves it too because revenue expansion happens naturally when adoption spreads.
+Speaker 2: It's like a gym membership that charges per visit; the more workouts, the more value for everyone.

--- a/content/part-05/usage-based-pricing/narratives/04-pitfalls.md
+++ b/content/part-05/usage-based-pricing/narratives/04-pitfalls.md
@@ -1,0 +1,4 @@
+Speaker 1: Of course, usage-based models aren't magic.
+Speaker 2: Revenue can swing wildly if customers binge one month and vanish the next.
+Speaker 1: Those surprises make forecasting tricky and can spook finance teams.
+Speaker 2: Transparent dashboards and billing alerts help customers avoid shock bills, keeping trust intact.

--- a/content/part-05/usage-based-pricing/narratives/05-churn-basics.md
+++ b/content/part-05/usage-based-pricing/narratives/05-churn-basics.md
@@ -1,0 +1,4 @@
+Speaker 1: Even with smart pricing, customers can drift away.
+Speaker 2: Churn happens when value fades or engagement drops below the effort of staying.
+Speaker 1: Spotting those early signals is vital because chasing new customers costs more than keeping the ones you have.
+Speaker 2: That's where health scoring enters the picture.

--- a/content/part-05/usage-based-pricing/narratives/06-health-scoring.md
+++ b/content/part-05/usage-based-pricing/narratives/06-health-scoring.md
@@ -1,0 +1,4 @@
+Speaker 1: A health score blends product signals like logins or feature use with softer data.
+Speaker 2: Support tickets, survey responses and contract age all feed into that single number.
+Speaker 1: A low score might mean the champion left or onboarding stalled.
+Speaker 2: With a shared score, sales and success teams know exactly which accounts need attention.

--- a/content/part-05/usage-based-pricing/narratives/07-acting-on-scores.md
+++ b/content/part-05/usage-based-pricing/narratives/07-acting-on-scores.md
@@ -1,0 +1,4 @@
+Speaker 1: Data only matters if you act on it.
+Speaker 2: When an account's score dips, schedule a check-in or offer training before renewal season.
+Speaker 1: Some teams trigger automated nudges that highlight unused features or success stories.
+Speaker 2: The goal is to restore momentum so customers feel supported, not sold to.

--- a/content/part-05/usage-based-pricing/narratives/08-takeaway.md
+++ b/content/part-05/usage-based-pricing/narratives/08-takeaway.md
@@ -1,0 +1,4 @@
+Speaker 1: When pricing mirrors usage, customers feel they're paying for real value, not shelfware.
+Speaker 2: Pair that with a health score and you spot trouble before contracts lapse.
+Speaker 1: It keeps revenue growing alongside satisfaction.
+Speaker 2: And that's the sweet spot—happy customers who stick around and expand.

--- a/content/part-05/usage-based-pricing/slides.md
+++ b/content/part-05/usage-based-pricing/slides.md
@@ -1,0 +1,61 @@
+---
+marp: true
+title: Usage-Based Pricing and Churn Prevention
+---
+
+# Usage-Based Pricing & Churn Prevention
+*Aligning revenue with customer value*
+
+---
+
+## What is usage-based pricing?
+Charges scale with consumption rather than fixed licences.
+It lowers initial commitment and grows as usage climbs.
+
+---
+
+## Common usage metrics
+- API calls or transactions
+- Data volume processed
+- Seats activated per month
+- Compute or storage hours
+
+---
+
+## Benefits
+- Fair mapping of cost to value
+- Easier entry for small customers
+- Expansion built into adoption
+
+---
+
+## Pitfalls to watch
+- Revenue becomes harder to forecast
+- Spiky bills can shock customers
+- Requires solid telemetry and billing
+
+---
+
+## Churn prevention basics
+Monitor adoption and support signals
+before customers quietly disengage.
+
+---
+
+## Customer health scoring
+Combine product usage, support tickets,
+NPS and contract age into a single score.
+
+---
+
+## Acting on health scores
+Target low-scoring accounts with
+enablement or incentives before renewal.
+
+---
+
+## Key takeaway
+Usage-based pricing ties price to value, and
+health scoring catches churn before it bites.
+
+---


### PR DESCRIPTION
## Summary
- add slide deck on usage-based pricing models and using customer health scores to prevent churn
- provide narrative scripts for each slide
- mark to-do item as complete

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b3f1e7cde8832586280387697f17ad