### PR TITLE
Add tech sales differences and buying committee content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -90,8 +90,8 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: CRM fundamentals using Salesforce Trailhead modules
   - [x] Draft slides and narrative: Key economics in tech sales: ARR vs one-time deals and land-and-expand growth
   - [x] Draft slides and narrative: Usage-based pricing models and churn prevention via customer health scoring
-  - [ ] Draft slides and narrative: How tech sales differs from other industries: recurring revenue models and rapid product cycles
-  - [ ] Draft slides and narrative: Multi-stakeholder buying committees and long deal cycles in enterprise tech
+  - [x] Draft slides and narrative: How tech sales differs from other industries: recurring revenue models and rapid product cycles
+  - [x] Draft slides and narrative: Multi-stakeholder buying committees and long deal cycles in enterprise tech
   - [ ] Draft slides and narrative: Close alignment with product teams for solution selling and technical validation
   - [ ] Draft slides and narrative: Sales engineering support: demo environments, RFP responses and integration planning
   - [ ] Draft slides and narrative: Customer success teams focused on adoption and expansion after go-live

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/01-intro.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/01-intro.md
@@ -1,4 +1,4 @@
-Speaker 1: Selling to an enterprise feels like pitching to a small town council.
+Speaker 1: Selling to an enterprise is like getting the extended family to agree on a restaurant.
 Speaker 2: Exactly, every department wants a say before signing a cheque.
 Speaker 1: So one enthusiastic contact isn't enough?
 Speaker 2: Not even close—you need consensus across the organisation.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/01-intro.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/01-intro.md
@@ -1,0 +1,4 @@
+Speaker 1: Selling to an enterprise feels like pitching to a small town council.
+Speaker 2: Exactly, every department wants a say before signing a cheque.
+Speaker 1: So one enthusiastic contact isn't enough?
+Speaker 2: Not even close—you need consensus across the organisation.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/02-process.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/02-process.md
@@ -1,4 +1,4 @@
 Speaker 1: What's the usual path a big company takes before buying?
-Speaker 2: They start with requirements, issue an RFP, then whittle down vendors for deep reviews.
-Speaker 1: And legal and security gatekeepers check everything.
-Speaker 2: Right, nothing moves until those teams sign off.
+Speaker 2: They gather requirements, issue an RFP and shortlist vendors for demos.
+Speaker 1: Then comes a pilot or proof of concept before contract talks.
+Speaker 2: And at a bank, even tiny deals sit in security and legal reviews for months—classic ITIL change control.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/02-process.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/02-process.md
@@ -1,0 +1,4 @@
+Speaker 1: What's the usual path a big company takes before buying?
+Speaker 2: They start with requirements, issue an RFP, then whittle down vendors for deep reviews.
+Speaker 1: And legal and security gatekeepers check everything.
+Speaker 2: Right, nothing moves until those teams sign off.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/03-roles.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/03-roles.md
@@ -1,0 +1,4 @@
+Speaker 1: Who sits on these committees anyway?
+Speaker 2: There's an economic buyer with the budget, a technical buyer checking architecture, and a champion pushing the project.
+Speaker 1: Don't forget procurement hunting for red flags.
+Speaker 2: Absolutely, each role has different worries you must address.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/03-roles.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/03-roles.md
@@ -1,4 +1,4 @@
 Speaker 1: Who sits on these committees anyway?
-Speaker 2: There's an economic buyer with the budget, a technical buyer checking architecture, and a champion pushing the project.
-Speaker 1: Don't forget procurement hunting for red flags.
-Speaker 2: Absolutely, each role has different worries you must address.
+Speaker 2: There's an economic buyer with budget, a technical buyer checking architecture, and a champion pushing the project.
+Speaker 1: Legal, compliance and even end users weigh in too.
+Speaker 2: Plus IT ops and procurement hunting for red flags—each has a different worry to address.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/04-long-cycles.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/04-long-cycles.md
@@ -1,4 +1,4 @@
 Speaker 1: These deals seem to drag on forever.
-Speaker 2: They can take six to twelve months with all the evaluations and approvals.
+Speaker 2: Six to twelve months is normal once procurement insists on getting the lowest price for the longest time.
 Speaker 1: What keeps them moving forward?
 Speaker 2: Regular check-ins and a clear paper trail so momentum isn't lost.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/04-long-cycles.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/04-long-cycles.md
@@ -1,0 +1,4 @@
+Speaker 1: These deals seem to drag on forever.
+Speaker 2: They can take six to twelve months with all the evaluations and approvals.
+Speaker 1: What keeps them moving forward?
+Speaker 2: Regular check-ins and a clear paper trail so momentum isn't lost.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/05-consensus.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/05-consensus.md
@@ -1,0 +1,4 @@
+Speaker 1: How do you win over so many voices?
+Speaker 2: Map out influencers and tailor messages to their goals.
+Speaker 1: So the security lead gets risk assurances while finance sees ROI.
+Speaker 2: Exactly, when each person feels heard the group moves to yes.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/05-consensus.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/05-consensus.md
@@ -1,4 +1,4 @@
 Speaker 1: How do you win over so many voices?
 Speaker 2: Map out influencers and tailor messages to their goals.
-Speaker 1: So the security lead gets risk assurances while finance sees ROI.
-Speaker 2: Exactly, when each person feels heard the group moves to yes.
+Speaker 1: A hospital project means doctors, IT ops, finance and compliance all get different slides.
+Speaker 2: Right, when each person feels heard the group finally moves to yes.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/06-takeaway.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/06-takeaway.md
@@ -1,4 +1,4 @@
 Speaker 1: So closing big deals is more diplomacy than pitching.
 Speaker 2: Totally. The win comes when every stakeholder believes the solution helps them.
-Speaker 1: Sounds like a marathon, not a sprint.
-Speaker 2: But finishing it can reshape the vendor's entire year.
+Speaker 1: Graduates might be the analyst keeping track of all those voices.
+Speaker 2: Stick with it—the marathon finish can reshape a vendor's entire year.

--- a/content/part-05/multi-stakeholder-buying-committees/narratives/06-takeaway.md
+++ b/content/part-05/multi-stakeholder-buying-committees/narratives/06-takeaway.md
@@ -1,0 +1,4 @@
+Speaker 1: So closing big deals is more diplomacy than pitching.
+Speaker 2: Totally. The win comes when every stakeholder believes the solution helps them.
+Speaker 1: Sounds like a marathon, not a sprint.
+Speaker 2: But finishing it can reshape the vendor's entire year.

--- a/content/part-05/multi-stakeholder-buying-committees/slides.md
+++ b/content/part-05/multi-stakeholder-buying-committees/slides.md
@@ -4,27 +4,32 @@ title: Multi-Stakeholder Buying Committees
 ---
 
 # Multi-Stakeholder Buying Committees
-*Navigating complex enterprise deals*
+*Navigating complex enterprise deals is like choosing a restaurant with the whole family*
 
 ---
 
 ## Enterprise purchase journey
-- Needs, RFP and vendor shortlists
-- Security and legal reviews
-- Final approval and rollout
+- Requirements, RFP and vendor shortlist
+- Pilot or proof of concept to test fit
+- Contract negotiation with procurement
+- Security and legal reviews before rollout
 
 ---
 
 ## Roles in the committee
 - Economic buyer controls budget
 - Technical buyer validates fit
-- Champions push internally
+- Champion pushes internally
+- Legal/compliance vets obligations
+- End users and IT ops assess practicality
+- Procurement checks costs
 
 ---
 
 ## Long deal cycles
-- Months of meetings and sign-offs
-- Procurement and risk teams weigh in
+- Six to twelve months of meetings
+- Pilots, security and compliance reviews
+- Procurement stretches pricing talks
 - Patience and documentation win
 
 ---
@@ -32,11 +37,12 @@ title: Multi-Stakeholder Buying Committees
 ## Mapping consensus
 - Identify influencers and blockers
 - Tailor value to each role
+- Hospital projects need doctors, IT, finance and compliance aligned
 - Track decisions over time
 
 ---
 
 ## Key takeaway
-Big deals close when every stakeholder sees their needs addressed.
+Big deals close when every stakeholder sees their needs addressed—and grads may help herd the cats.
 
 ---

--- a/content/part-05/multi-stakeholder-buying-committees/slides.md
+++ b/content/part-05/multi-stakeholder-buying-committees/slides.md
@@ -1,0 +1,42 @@
+---
+marp: true
+title: Multi-Stakeholder Buying Committees
+---
+
+# Multi-Stakeholder Buying Committees
+*Navigating complex enterprise deals*
+
+---
+
+## Enterprise purchase journey
+- Needs, RFP and vendor shortlists
+- Security and legal reviews
+- Final approval and rollout
+
+---
+
+## Roles in the committee
+- Economic buyer controls budget
+- Technical buyer validates fit
+- Champions push internally
+
+---
+
+## Long deal cycles
+- Months of meetings and sign-offs
+- Procurement and risk teams weigh in
+- Patience and documentation win
+
+---
+
+## Mapping consensus
+- Identify influencers and blockers
+- Tailor value to each role
+- Track decisions over time
+
+---
+
+## Key takeaway
+Big deals close when every stakeholder sees their needs addressed.
+
+---

--- a/content/part-05/tech-sales-differences/narratives/01-intro.md
+++ b/content/part-05/tech-sales-differences/narratives/01-intro.md
@@ -1,0 +1,4 @@
+Speaker 1: Selling software isn't like selling a car that drives off the lot once.
+Speaker 2: Right, customers expect constant updates and ongoing value, not a one-time purchase.
+Speaker 1: So the relationship lasts as long as the subscription does.
+Speaker 2: Exactly, which keeps both sides invested after the contract is signed.

--- a/content/part-05/tech-sales-differences/narratives/01-intro.md
+++ b/content/part-05/tech-sales-differences/narratives/01-intro.md
@@ -1,4 +1,4 @@
-Speaker 1: Selling software isn't like selling a car that drives off the lot once.
-Speaker 2: Right, customers expect constant updates and ongoing value, not a one-time purchase.
-Speaker 1: So the relationship lasts as long as the subscription does.
-Speaker 2: Exactly, which keeps both sides invested after the contract is signed.
+Speaker 1: Selling software isn't like handing over car keys and waving goodbye.
+Speaker 2: Right, no more "always be closing"—now it's "always be retaining".
+Speaker 1: The relationship keeps going as long as customers log in.
+Speaker 2: Exactly, upgrades and renewals keep both sides talking.

--- a/content/part-05/tech-sales-differences/narratives/02-recurring-revenue.md
+++ b/content/part-05/tech-sales-differences/narratives/02-recurring-revenue.md
@@ -1,0 +1,4 @@
+Speaker 1: Recurring revenue sounds great but doesn't it add pressure to retain every client?
+Speaker 2: It does. Losing a customer means future income vanishes, so renewals become life or death.
+Speaker 1: That explains why support teams hover after sign-off.
+Speaker 2: They need proof people use the product or the subscription won't renew.

--- a/content/part-05/tech-sales-differences/narratives/02-recurring-revenue.md
+++ b/content/part-05/tech-sales-differences/narratives/02-recurring-revenue.md
@@ -1,4 +1,4 @@
 Speaker 1: Recurring revenue sounds great but doesn't it add pressure to retain every client?
-Speaker 2: It does. Losing a customer means future income vanishes, so renewals become life or death.
-Speaker 1: That explains why support teams hover after sign-off.
+Speaker 2: Totally. Netflix's shift from DVDs to streaming showed how one lost viewer hurts the model.
+Speaker 1: So support teams hover after sign-off.
 Speaker 2: They need proof people use the product or the subscription won't renew.

--- a/content/part-05/tech-sales-differences/narratives/03-land-and-expand.md
+++ b/content/part-05/tech-sales-differences/narratives/03-land-and-expand.md
@@ -1,0 +1,4 @@
+Speaker 1: What's this land-and-expand idea everyone mentions?
+Speaker 2: You win a small deal first, show value, then grow the footprint inside that account.
+Speaker 1: So instead of chasing one giant contract, you build trust over time.
+Speaker 2: Exactly, expansions feel lower risk to buyers and keep revenue climbing.

--- a/content/part-05/tech-sales-differences/narratives/03-land-and-expand.md
+++ b/content/part-05/tech-sales-differences/narratives/03-land-and-expand.md
@@ -1,4 +1,4 @@
 Speaker 1: What's this land-and-expand idea everyone mentions?
 Speaker 2: You win a small deal first, show value, then grow the footprint inside that account.
-Speaker 1: So instead of chasing one giant contract, you build trust over time.
-Speaker 2: Exactly, expansions feel lower risk to buyers and keep revenue climbing.
+Speaker 1: Salesforce started with a few sales reps before taking over whole companies.
+Speaker 2: Slack and Zoom even seed free teams; sales engineers jump in once usage explodes.

--- a/content/part-05/tech-sales-differences/narratives/04-rapid-cycles.md
+++ b/content/part-05/tech-sales-differences/narratives/04-rapid-cycles.md
@@ -1,4 +1,4 @@
 Speaker 1: Features seem to change every sprint. How do sales teams keep up?
-Speaker 2: Continuous training. Product managers brief reps weekly so pitches stay current.
-Speaker 1: That sounds exhausting compared to yearly hardware refreshes.
-Speaker 2: True, but it's also a chance to re-engage customers with fresh capabilities.
+Speaker 2: Weekly briefings with product and sales engineers keep pitches current.
+Speaker 1: Then they watch dashboards like parents tracking a teenager to see who tries the new stuff.
+Speaker 2: Adoption cues them on which upgrade to mention next.

--- a/content/part-05/tech-sales-differences/narratives/04-rapid-cycles.md
+++ b/content/part-05/tech-sales-differences/narratives/04-rapid-cycles.md
@@ -1,0 +1,4 @@
+Speaker 1: Features seem to change every sprint. How do sales teams keep up?
+Speaker 2: Continuous training. Product managers brief reps weekly so pitches stay current.
+Speaker 1: That sounds exhausting compared to yearly hardware refreshes.
+Speaker 2: True, but it's also a chance to re-engage customers with fresh capabilities.

--- a/content/part-05/tech-sales-differences/narratives/05-metrics.md
+++ b/content/part-05/tech-sales-differences/narratives/05-metrics.md
@@ -1,4 +1,4 @@
 Speaker 1: Why do tech companies obsess over ARR and churn rates?
-Speaker 2: Because those numbers predict the health of the business better than one-off bookings.
-Speaker 1: So a tiny uptick in churn can wipe out growth.
-Speaker 2: Exactly, which is why data teams watch usage telemetry like hawks.
+Speaker 2: Those numbers predict the health of the business better than one-off bookings.
+Speaker 1: Freemium funnels must convert or churn wipes out growth.
+Speaker 2: Exactly, reps stare at usage dashboards like hawks.

--- a/content/part-05/tech-sales-differences/narratives/05-metrics.md
+++ b/content/part-05/tech-sales-differences/narratives/05-metrics.md
@@ -1,0 +1,4 @@
+Speaker 1: Why do tech companies obsess over ARR and churn rates?
+Speaker 2: Because those numbers predict the health of the business better than one-off bookings.
+Speaker 1: So a tiny uptick in churn can wipe out growth.
+Speaker 2: Exactly, which is why data teams watch usage telemetry like hawks.

--- a/content/part-05/tech-sales-differences/narratives/06-takeaway.md
+++ b/content/part-05/tech-sales-differences/narratives/06-takeaway.md
@@ -1,4 +1,4 @@
 Speaker 1: So tech sales is really a long-term partnership, not a hit-and-run.
-Speaker 2: Exactly. The faster the product evolves, the more contact you maintain.
-Speaker 1: Which means success hinges on ongoing trust and measurable results.
-Speaker 2: Nail those and customers stick around for the next upgrade.
+Speaker 2: Yep, you'll work with success managers and engineers after the deal.
+Speaker 1: Graduates might enter as customer success or sales engineer roles.
+Speaker 2: Keep trust and results front and centre and renewals follow.

--- a/content/part-05/tech-sales-differences/narratives/06-takeaway.md
+++ b/content/part-05/tech-sales-differences/narratives/06-takeaway.md
@@ -1,0 +1,4 @@
+Speaker 1: So tech sales is really a long-term partnership, not a hit-and-run.
+Speaker 2: Exactly. The faster the product evolves, the more contact you maintain.
+Speaker 1: Which means success hinges on ongoing trust and measurable results.
+Speaker 2: Nail those and customers stick around for the next upgrade.

--- a/content/part-05/tech-sales-differences/slides.md
+++ b/content/part-05/tech-sales-differences/slides.md
@@ -10,33 +10,37 @@ title: Tech Sales vs Other Industries
 
 ## Recurring revenue models
 - Subscriptions replace one-off deals
-- Revenue depends on retention
-- Land-and-expand beats big bang sales
+- Retention is king—no more "always be closing"
+- Netflix's DVD-to-streaming shift shows subscription power
+- Free trials hook users before the first invoice
 
 ---
 
 ## Land and expand mindset
 - Start small then grow account value
-- Success teams drive adoption
-- Upsells rely on proof of value
+- Salesforce landed a team then rolled out company-wide
+- Slack and Zoom seed free teams before sales calls
+- Sales engineers help validate technical fit
 
 ---
 
 ## Rapid product cycles
 - Releases ship weekly not yearly
-- Sales must learn features fast
-- Feedback loops tighten
+- Reps and sales engineers brief constantly
+- Dashboards show which features customers adopt
+- Product-led growth turns usage into new pitches
 
 ---
 
 ## Metrics obsession
 - ARR, MRR and churn rates matter
-- Usage telemetry guides outreach
+- Usage telemetry guides outreach; reps check dashboards like anxious parents
+- Freemium funnels require conversion tracking
 - Forecasts update constantly
 
 ---
 
 ## Key takeaway
-Tech sales thrives on ongoing relationships and quick iteration.
+Tech sales blends product-led growth, sales engineering and relentless retention.
 
 ---

--- a/content/part-05/tech-sales-differences/slides.md
+++ b/content/part-05/tech-sales-differences/slides.md
@@ -1,0 +1,42 @@
+---
+marp: true
+title: Tech Sales vs Other Industries
+---
+
+# Tech Sales vs Other Industries
+*Recurring revenue and rapid change*
+
+---
+
+## Recurring revenue models
+- Subscriptions replace one-off deals
+- Revenue depends on retention
+- Land-and-expand beats big bang sales
+
+---
+
+## Land and expand mindset
+- Start small then grow account value
+- Success teams drive adoption
+- Upsells rely on proof of value
+
+---
+
+## Rapid product cycles
+- Releases ship weekly not yearly
+- Sales must learn features fast
+- Feedback loops tighten
+
+---
+
+## Metrics obsession
+- ARR, MRR and churn rates matter
+- Usage telemetry guides outreach
+- Forecasts update constantly
+
+---
+
+## Key takeaway
+Tech sales thrives on ongoing relationships and quick iteration.
+
+---


### PR DESCRIPTION
## Summary
- add slides and dialogue covering recurring revenue, land-and-expand sales and rapid product cycles
- outline multi-stakeholder buying committees and challenges of long enterprise deal cycles
- check off completed items in TODO list

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b4b29c14c083258a597b16f9a136ab