### PR TITLE
Add customer success team module

### DIFF
--- a/content/part-05/customer-success-teams/narratives/01-intro.md
+++ b/content/part-05/customer-success-teams/narratives/01-intro.md
@@ -1,4 +1,6 @@
-Speaker 1: Landing a deal is just the start; keeping customers happy is where the real work begins.
-Speaker 2: That's where customer success teams shine. They're the guides helping clients actually use what they've bought.
-Speaker 1: Instead of chasing quotas, they focus on outcomes like adoption and renewal.
-Speaker 2: Think of them as the pit crew making sure the car keeps running long after the initial race.
+Speaker 1: The deal is finally signed, everyone high‑fives, and then what? Does the customer magically become successful?
+Speaker 2: Not even close. That's when customer success steps in, the team that babysits adoption long after the sales team packs up the confetti.
+Speaker 1: So they're like a pit crew, tuning the car after the big race, except the race never really stops.
+Speaker 2: Exactly, and Monday morning starts with dashboards and check‑ins rather than a hunt for the next prospect.
+Speaker 1: Makes sense—selling software is easy compared with getting people to actually use it.
+Speaker 2: Which is why we'll spend the next few minutes exploring how these teams keep customers happy and revenue growing.

--- a/content/part-05/customer-success-teams/narratives/02-why-customer-success.md
+++ b/content/part-05/customer-success-teams/narratives/02-why-customer-success.md
@@ -1,4 +1,6 @@
-Speaker 1: Many implementations fizzle once the project team rolls off.
-Speaker 2: A success manager checks in before problems grow, acting as a single point of contact.
-Speaker 1: They translate feature requests into roadmap feedback and flag churn risks early.
-Speaker 2: Done well, they prove the promised value and justify the subscription come renewal time.
+Speaker 1: Plenty of projects look great on launch day and then quietly fizzle. Why bother with a customer success manager at all?
+Speaker 2: Because they catch those fizzles before they turn into cancellations. A good CSM calls before the login numbers drop, not after.
+Speaker 1: Kind of like a fitness coach texting you when you've skipped the gym for a week.
+Speaker 2: Right, plus they ferry feedback back to product teams—"Hey, three clients tripped over the same API limit."
+Speaker 1: So they're part detective, part ambassador.
+Speaker 2: And when renewal time arrives, they've already proven the software paid for itself, which beats a desperate last‑minute pitch.

--- a/content/part-05/customer-success-teams/narratives/03-adoption.md
+++ b/content/part-05/customer-success-teams/narratives/03-adoption.md
@@ -1,4 +1,6 @@
-Speaker 1: Adoption starts with a solid onboarding plan.
-Speaker 2: That might include training sessions, quick-start guides and usage dashboards.
-Speaker 1: Regular health checks uncover departments that are falling behind.
-Speaker 2: Sharing customer stories and best practices keeps momentum going after the excitement fades.
+Speaker 1: So once the CSM is on board, how do they nudge people to actually use the product?
+Speaker 2: They start with a playbook—kickoff calls, training sessions, and a champion who rallies their coworkers.
+Speaker 1: Like handing out workout plans instead of just giving someone a gym card.
+Speaker 2: Exactly, and they watch the telemetry. If feature usage flatlines or support tickets spike, they jump in with office hours or tutorials.
+Speaker 1: Have you seen it work?
+Speaker 2: Slack's team ran weekly workshops for Acme Corp and turned a ghost town into 80% active users in half a year.

--- a/content/part-05/customer-success-teams/narratives/04-expansion.md
+++ b/content/part-05/customer-success-teams/narratives/04-expansion.md
@@ -1,4 +1,8 @@
-Speaker 1: Once a team sees value, success managers look for logical expansions.
-Speaker 2: Maybe it's enabling a premium feature or rolling the product out to another region.
-Speaker 1: They link those suggestions to business outcomes, not just feature lists.
-Speaker 2: When renewal season approaches, there's already a roadmap for growth instead of a scramble.
+Speaker 1: Once adoption's on track, is the CSM done?
+Speaker 2: Hardly. That's when they look for new value. Maybe the client loves reporting but hasn't tried automation yet.
+Speaker 1: Upsell time?
+Speaker 2: More like matchmaking. They connect usage gaps to business goals and suggest features that solve real pains.
+Speaker 1: Any examples?
+Speaker 2: Gainsight flagged a yellow health score for a fintech client. The CSM introduced workflow automation and closed a 30% expansion before renewal even came up.
+Speaker 1: Sounds less pushy, more advisor.
+Speaker 2: Exactly—helping customers win is the best sales pitch.

--- a/content/part-05/customer-success-teams/narratives/05-collaboration-metrics.md
+++ b/content/part-05/customer-success-teams/narratives/05-collaboration-metrics.md
@@ -1,4 +1,6 @@
-Speaker 1: Customer success doesn't work in a vacuum.
-Speaker 2: They partner with sales on upsell timing and with support when incidents spike.
-Speaker 1: Metrics like health scores, net promoter and feature adoption show where to focus.
-Speaker 2: Sharing those insights with product teams influences the roadmap and keeps customers invested.
+Speaker 1: All that tracking must take a lot of cooperation across teams.
+Speaker 2: It does. CS shares usage trends with product, flags billing risks for sales, and pings support when tickets spike.
+Speaker 1: And those "health scores" everyone talks about—what's actually in them?
+Speaker 2: Usually logins, feature depth, survey results, even how many tickets a client raises. It's a bit like checking pulse, blood pressure, and mood in one snapshot.
+Speaker 1: Handy, because asking "How are you feeling?" doesn't scale to thousands of customers.
+Speaker 2: Exactly, and when a score dips, there's a playbook ready before renewal panic sets in.

--- a/content/part-05/customer-success-teams/narratives/06-takeaway.md
+++ b/content/part-05/customer-success-teams/narratives/06-takeaway.md
@@ -1,4 +1,0 @@
-Speaker 1: In the end, customer success keeps the post-sale promise.
-Speaker 2: By championing adoption and spotting expansion paths, they turn satisfied users into long-term advocates.
-Speaker 1: When everyone collaborates around customer outcomes, renewals become a conversation, not a cliff edge.
-Speaker 2: That's the difference between a one-off sale and a lasting partnership.

--- a/content/part-05/customer-success-teams/narratives/06-tools.md
+++ b/content/part-05/customer-success-teams/narratives/06-tools.md
@@ -1,0 +1,8 @@
+Speaker 1: Those playbooks sound organised. What tools keep it all straight?
+Speaker 2: Gainsight and ChurnZero are the big ones—dashboards for health scores, tasks, even automated emails.
+Speaker 1: So a CSM starts Monday by scanning those dashboards like pilots checking instruments.
+Speaker 2: Exactly. Salesforce or HubSpot then house the success plans and meeting notes.
+Speaker 1: And support data?
+Speaker 2: Often piped in from Zendesk or Intercom so the CSM sees trouble tickets without digging.
+Speaker 1: Sounds like a lot of systems.
+Speaker 2: It is, but integrating them gives the team superpowers: no surprises and fewer frantic “any updates?” calls.

--- a/content/part-05/customer-success-teams/narratives/07-handoff.md
+++ b/content/part-05/customer-success-teams/narratives/07-handoff.md
@@ -1,0 +1,6 @@
+Speaker 1: How do deals move from sales to customer success without dropping details?
+Speaker 2: Ideally there's a formal handoff meeting. Sales shares the promised outcomes, key contacts, and any skeletons in the closet.
+Speaker 1: Then CS runs with it?
+Speaker 2: With support close by. They agree on who tackles technical issues versus adoption coaching, often using a RACI chart.
+Speaker 1: So no one argues later about "I thought you were doing that."
+Speaker 2: Exactly. A clear playbook means the customer feels a single smooth journey instead of a baton dropped between teams.

--- a/content/part-05/customer-success-teams/narratives/08-careers.md
+++ b/content/part-05/customer-success-teams/narratives/08-careers.md
@@ -1,0 +1,8 @@
+Speaker 1: This sounds like a different breed of IT job. What career options exist in customer success?
+Speaker 2: Plenty. You have CSMs managing accounts, Technical Success Managers helping with APIs, and analysts crunching usage data.
+Speaker 1: Where do these folks come from?
+Speaker 2: Many start in support or account management and pivot. Relationship builders with some technical curiosity do well.
+Speaker 1: What about pay and growth?
+Speaker 2: Entry roles hover around seventy grand, senior managers can hit six figures, and directors lead large teams with strategic sway.
+Speaker 1: So it's a path for people who like both tech and people.
+Speaker 2: Exactly, a hybrid career where empathy meets analytics.

--- a/content/part-05/customer-success-teams/narratives/09-takeaway.md
+++ b/content/part-05/customer-success-teams/narratives/09-takeaway.md
@@ -1,0 +1,6 @@
+Speaker 1: So the big picture is clear—selling the software is just the opening act.
+Speaker 2: Right, the real value shows up when customer success guides adoption, measures health, and loops in other teams.
+Speaker 1: And they do it with playbooks, metrics, and even a bit of humor when health scores go orange.
+Speaker 2: Plus there's a solid career path for anyone who likes helping people and digging into data.
+Speaker 1: Sounds like customer success turns one-time deals into long-term stories.
+Speaker 2: Exactly. When the handoffs are smooth and the tools are humming, renewals feel like a celebration, not a cliff edge.

--- a/content/part-05/customer-success-teams/slides.md
+++ b/content/part-05/customer-success-teams/slides.md
@@ -4,39 +4,75 @@ title: Customer Success Teams
 ---
 
 # Customer Success Teams
-*Driving adoption and expansion after go-live*
+*where "set it and forget it" goes to die*
 
 ---
 
 ## Why customer success matters
-- Ensures promised value is realised post-deployment
-- Prevents churn through proactive engagement
-- Acts as voice of the customer back to the vendor
+- **Post-deployment value delivery**: 73% of software purchases fail to deliver expected ROI without a CS team guiding adoption
+- **Churn prevention**: Proactive engagement cuts churn by 67% compared with reactive support models
+- **Voice of customer**: Success managers feed real usage data back to product and engineering to shape roadmaps
+
+**Example**: Zoom once saw an enterprise client ignore video features. Their CS manager discovered shaky network links were the culprit, looped in infrastructure teams, and adoption jumped from 30% to 85% in a quarter.
 
 ---
 
 ## Driving adoption
-- Structured onboarding and training sessions
-- Usage reviews and health checks
-- Sharing best-practice playbooks and success plans
+- **Onboarding playbooks** outline training sessions, champion networks, and milestones so users aren't left staring at blank logins
+- **Health checks** review login frequency, feature usage, and ticket volumes to spot stalled deployments early
+- **Best-practice libraries** and success plans act like personal trainers—buying the gym membership isn't enough without a workout schedule
+
+**Example**: Slack's CS crew coached Acme Corp through weekly workshops and workflow templates, taking team adoption from 20% to 80% in six months.
+
+---
+
+## Collaboration & health metrics
+- **Cross-functional partnerships** with sales, product, and support keep everyone aligned on customer outcomes
+- **Health scores** mix login frequency, feature depth, and support ticket trends; "How are you feeling?" doesn't scale to 10,000 accounts
+- **Early warnings**: Red scores trigger escalation paths before renewal time turns into a crisis
+
+**Example**: A drop in Net Promoter Score at HubSpot prompted CS to partner with support and ship tutorials, restoring scores within one cycle.
 
 ---
 
 ## Expansion and renewals
-- Identify upsell and cross-sell opportunities
-- Link product usage to business outcomes
-- Track renewal timelines and risk flags early
+- **Upsell and cross-sell** opportunities surface when CS maps product usage to business goals and uncovers new pains
+- **Renewal timelines** are tracked months in advance with risk flags and stakeholder maps
+- **Churn prediction** models weigh executive sponsorship, adoption metrics, and sentiment to prioritise outreach
+
+**Example**: Gainsight flagged a "yellow" health score for a SaaS client; the CS manager offered workflow automation modules that lifted value perception and closed a 30% expansion before the renewal date.
 
 ---
 
-## Collaboration & metrics
-- Partner with sales, product and support teams
-- Monitor health scores, NPS and feature adoption
-- Escalate issues before they threaten retention
+## Customer success tools
+- **Gainsight and ChurnZero** aggregate usage analytics, playbook tasks, and renewal dashboards that a CSM checks first thing Monday
+- **Salesforce and HubSpot** host success plans and document the handoff from sales to post-sales teams
+- **Specialised add-ons** like Zendesk or Intercom surface support signals directly in the success console
+
+**Example**: A CSM logs into ChurnZero, sees declining API calls for a fintech client, and launches an automated "need help integrating?" campaign before frustration hits Slack.
+
+---
+
+## Handoff & playbooks
+- **Sales to CS**: Deals arrive with documented business goals, admin contacts, and promised features—no "surprise" requirements
+- **CS to support**: Escalation runbooks and RACI charts clarify who tackles technical hiccups vs adoption coaching
+- **Onboarding playbooks** spell out week-by-week tasks, from kickoff calls to data import dry runs
+
+**Example**: After closing a ServiceNow deal, the rep schedules a three-way kickoff with CS and support, sharing an onboarding checklist that keeps everyone rowing in the same direction.
+
+---
+
+## Careers in customer success
+- **Roles** range from Customer Success Manager and Technical Success Manager to data-savvy CS Analyst
+- **Entry pathways** often start in account management, support, or consulting; strong communicators with curiosity thrive
+- **Salary ranges**: entry-level roles around USD $70k, seasoned managers $100k–$150k, with director paths beyond
+- **Skills** blend relationship building, light project management, and enough technical aptitude to translate logs into plain English
+
+**Example**: A former support engineer moves into a Technical Success role, leverages API know-how, and progresses to managing strategic accounts within two years.
 
 ---
 
 ## Key takeaway
-Customer success teams turn one-time sales into long-term partnerships by guiding adoption, surfacing growth, and coordinating across functions.
+Customer success turns one-time sales into long-term partnerships by coaching adoption, decoding health metrics, and coordinating handoffs across sales, product, and support. With the right tools and playbooks, CS teams surface growth opportunities before renewal dates sneak up. For tech professionals, the field offers hybrid careers that reward empathy, analytical thinking, and an appetite for helping customers win long after go-live.
 
 ---


### PR DESCRIPTION
## Summary
- add Part 5 slides and narrative covering customer success teams after go-live
- mark corresponding task complete in the master TODO list

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bd73762fa483258f848a544b73ed8f