### PR TITLE
Add lead scoring and renewal alert content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -95,7 +95,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Close alignment with product teams for solution selling and technical validation
   - [x] Draft slides and narrative: Sales engineering support: demo environments, RFP responses and integration planning
   - [x] Draft slides and narrative: Customer success teams focused on adoption and expansion after go-live
-  - [ ] Draft slides and narrative: Lead scoring, opportunity progression and renewal alerts in CRM workflows
+  - [x] Draft slides and narrative: Lead scoring, opportunity progression and renewal alerts in CRM workflows
   - [ ] Draft slides and narrative: Linking CRM milestones to ITIL change and incident processes
   - [ ] Draft slides and narrative: Hands-on scenario: walk through a Salesforce CRM opportunity from lead to close
 - [ ] Create quiz questions

--- a/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/01-why-scoring-matters.md
+++ b/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/01-why-scoring-matters.md
@@ -1,0 +1,5 @@
+Speaker 1: Picture an account executive juggling twenty live deals and forty inbound leads.
+Speaker 2: Without prioritisation, the hottest buyer might wait three days for a reply while a tyre-kicker gets all the attention.
+Speaker 1: Lead scoring ranks prospects so the CRM surfaces the conversations most likely to close.
+Speaker 2: The same discipline applies to renewals—alerts on usage drops or contract anniversaries give time to intervene.
+Speaker 1: When you combine both, the CRM stops being a passive database and becomes an active workflow coach for the revenue team.

--- a/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/02-lead-scoring-fundamentals.md
+++ b/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/02-lead-scoring-fundamentals.md
@@ -1,0 +1,5 @@
+Speaker 1: We split scoring signals into explicit and implicit.
+Speaker 2: Explicit means facts about the lead—industry, company size, job title, tech stack compatibility.
+Speaker 1: Implicit signals show intent, like downloading the pricing guide, attending a webinar or requesting a sandbox.
+Speaker 2: Marketing and sales must agree on what score equals "marketing-qualified" so hand-offs are automatic, not debate material.
+Speaker 1: Document those definitions inside the CRM fields and playbooks so new hires follow the same rules from day one.

--- a/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/03-building-the-model.md
+++ b/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/03-building-the-model.md
@@ -1,0 +1,5 @@
+Speaker 1: Start with a basic formula rather than an opaque AI model.
+Speaker 2: Maybe ten points for being in your ideal customer profile, five for a director or above, fifteen for booking a demo.
+Speaker 1: Deduct points for students, partners researching you for their own clients or anyone outside target regions.
+Speaker 2: Every quarter, compare scores on closed-won deals versus lost deals and adjust the weights.
+Speaker 1: Transparency matters—if reps understand why a lead is 85 points, they will trust the automation and act quickly.

--- a/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/04-opportunity-stage-progression.md
+++ b/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/04-opportunity-stage-progression.md
@@ -1,0 +1,5 @@
+Speaker 1: Scoring gets leads into the pipeline, but stage definitions keep deals moving.
+Speaker 2: Agree on exit criteria like "Qualified means we know budget, authority, need and timeline".
+Speaker 1: When a proposal is sent, log the mutual action plan or next meeting date so leadership can coach instead of guess.
+Speaker 2: Accurate close dates and next steps make pipeline reviews collaborative rather than uncomfortable interrogations.
+Speaker 1: It also feeds more reliable forecasts to finance, which keeps the business trusting the sales org.

--- a/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/05-automation-and-queues.md
+++ b/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/05-automation-and-queues.md
@@ -1,0 +1,5 @@
+Speaker 1: Automation stops opportunities falling through the cracks.
+Speaker 2: When a lead crosses the marketing-qualified threshold, auto-create an opportunity and assign the right account executive.
+Speaker 1: Mid-score leads can drop into nurture sequences that drip education until intent spikes again.
+Speaker 2: If a deal stalls longer than its normal stage duration, trigger a task or manager alert so someone re-engages.
+Speaker 1: Systems handle the nudges; humans focus on quality conversations.

--- a/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/06-renewal-alerts.md
+++ b/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/06-renewal-alerts.md
@@ -1,0 +1,5 @@
+Speaker 1: Renewals deserve the same rigour as new business.
+Speaker 2: Tag every account with contract start dates, renewal deadlines and notice periods so alerts fire in advance.
+Speaker 1: Pull usage, NPS and support data into the CRM to colour-code health—green, amber, red.
+Speaker 2: Monthly customer success reviews on the 120, 90 and 60-day lists give plenty of time to resolve issues or plan upsells.
+Speaker 1: It feels much better to call with a success plan than to apologise after a surprise cancellation.

--- a/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/07-metrics-to-track.md
+++ b/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/07-metrics-to-track.md
@@ -1,0 +1,5 @@
+Speaker 1: Metrics prove whether the process works.
+Speaker 2: Track lead-to-opportunity conversion and compare the average score of deals you win versus those you lose.
+Speaker 1: Stage aging reports show where deals stall so you can refine exit criteria or coaching.
+Speaker 2: Renewal retention rate and forecast accuracy tell finance whether to trust the numbers coming from salesforce dashboards.
+Speaker 1: Share insights with marketing so campaign targeting mirrors the behaviour of leads who actually convert.

--- a/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/08-careers-and-collaboration.md
+++ b/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/08-careers-and-collaboration.md
@@ -1,0 +1,5 @@
+Speaker 1: Who owns all this plumbing? Usually revenue operations.
+Speaker 2: RevOps analysts translate between marketing automation, sales processes and customer success playbooks.
+Speaker 1: Marketing operations specialists curate the scoring logic while customer success managers interpret renewal health signals.
+Speaker 2: Entry-level coordinators might clean data, build dashboards or test workflows before stepping into manager roles.
+Speaker 1: Curiosity about buyer behaviour and the ability to facilitate cross-team workshops are the career superpowers here.

--- a/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/09-key-takeaway.md
+++ b/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/narratives/09-key-takeaway.md
@@ -1,0 +1,5 @@
+Speaker 1: The goal isn’t a flashy dashboard, it’s predictable growth.
+Speaker 2: Keep the scoring model simple, enforce stage hygiene and schedule renewal reviews like clockwork.
+Speaker 1: Automate the reminders but regularly sanity-check them against real conversations.
+Speaker 2: When data, process and people stay aligned, the CRM becomes the nervous system of revenue operations.
+Speaker 1: That discipline is what separates teams who scramble at quarter end from those who hit plan consistently.

--- a/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/slides.md
+++ b/content/part-05/lead-scoring-opportunity-progression-renewal-alerts/slides.md
@@ -1,0 +1,63 @@
+---
+marp: true
+title: Lead Scoring, Opportunity Progression and Renewal Alerts
+---
+
+# Lead Scoring & Renewal Signals
+*Keeping CRM pipelines healthy*
+
+---
+
+## Why scoring and alerts matter
+
+Sales teams juggle dozens of leads and renewal dates. Without a system, hot prospects cool off and at-risk renewals slip. Lead scoring ranks prospects using behaviour and firmographic signals so reps focus on the right conversations. Renewal alerts surface usage dips or contract anniversaries before customers churn. Together they turn the CRM from a database into a proactive workflow coach.
+
+---
+
+## Lead scoring fundamentals
+
+Assign points for traits that correlate with wins. Explicit data covers company size, industry fit or decision-maker seniority. Implicit signals track engagement—email opens, webinar attendance, product trials. Define what counts as "marketing-qualified" versus "sales-qualified" and document it in the CRM so automation knows when to hand leads between teams.
+
+---
+
+## Building the scoring model
+
+Start simple: +10 points for ICP industry, +5 for director-level titles, +15 for a demo request. Subtract points for students or competitors. Review closed-won data quarterly to adjust weights. Tools like HubSpot, Salesforce or Pipedrive support formula fields or Einstein/AI scoring, but the logic should remain transparent so sellers trust the numbers.
+
+---
+
+## Opportunity stage progression
+
+Create clear exit criteria for each pipeline stage—"Qualified" means budget, authority, need and timeline confirmed. "Proposal" requires pricing sent and mutual action plan agreed. Reps should update close dates and next steps on every call. Consistent hygiene powers forecasting accuracy and makes pipeline reviews collaborative instead of interrogations.
+
+---
+
+## Automation and task queues
+
+Use CRM workflows to convert high-scoring leads into opportunities, notify account executives and add tasks. Sequence emails can nurture mid-tier scores until they are ready. When opportunities stagnate past the expected duration, trigger reminders or manager check-ins. Automations keep momentum without relying on memory.
+
+---
+
+## Renewal alerts and health signals
+
+Tag every account with contract start, renewal and notice periods. Integrate product usage or support ticket data to flag declining logins, low NPS or unresolved issues. Create dashboards showing accounts 120/90/60 days from renewal with health colour codes. Customer success and sales should meet monthly to action the list before any surprises reach the finance team.
+
+---
+
+## Metrics to track
+
+Monitor lead-to-opportunity conversion, average score of closed-won deals, stage aging and renewal retention rate. Compare forecast accuracy before and after automation. Share insights with marketing so campaign targeting reflects real buyer behaviour. Metrics turn anecdotal pipeline conversations into measurable improvements.
+
+---
+
+## Careers and collaboration
+
+Revenue operations analysts design scoring models, marketing operations maintain automations and customer success managers interpret renewal signals. Entry-level coordinators might clean data or build reports before progressing to RevOps manager or lifecycle marketing roles. Soft skills like stakeholder facilitation and curiosity about customer behaviour make these careers thrive.
+
+---
+
+## Key takeaway
+
+Lead scoring, disciplined stage management and proactive renewal alerts keep revenue teams focused on the right actions at the right time. Start with simple rules, automate hand-offs and continuously refine using closed-loop data. The CRM then becomes the nerve centre of predictable growth rather than a graveyard of stale records.
+
+---


### PR DESCRIPTION
## Summary
- add Part 5 slides covering lead scoring, pipeline progression, automation, and renewal alert practices
- write companion dual-speaker narratives for each new slide to guide audio production
- check off the corresponding item in the master TODO list

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cecbfa46ec83258f04dacf390a21f2