### PR TITLE
Add Part 5 CRM-ITIL integration and Salesforce opportunity walkthrough

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -96,8 +96,8 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Sales engineering support: demo environments, RFP responses and integration planning
   - [x] Draft slides and narrative: Customer success teams focused on adoption and expansion after go-live
   - [x] Draft slides and narrative: Lead scoring, opportunity progression and renewal alerts in CRM workflows
-  - [ ] Draft slides and narrative: Linking CRM milestones to ITIL change and incident processes
-  - [ ] Draft slides and narrative: Hands-on scenario: walk through a Salesforce CRM opportunity from lead to close
+  - [x] Draft slides and narrative: Linking CRM milestones to ITIL change and incident processes
+  - [x] Draft slides and narrative: Hands-on scenario: walk through a Salesforce CRM opportunity from lead to close
 - [ ] Create quiz questions
 
 #### Part 6 – Start-ups & Small-Biz IT

--- a/content/part-05/linking-crm-milestones/narratives/01-intro.md
+++ b/content/part-05/linking-crm-milestones/narratives/01-intro.md
@@ -1,0 +1,5 @@
+Speaker 1: Welcome to the session on connecting CRM milestones with ITIL processes. We're going to look at how a Salesforce pip
+eline can become more than a sales tool—it can be an early-warning radar for service delivery teams.
+
+Speaker 2: Exactly. When the right data flows from sales to service, change managers know what's coming, incident teams know the
+ customer context, and executives see fewer surprises. Think of it as stitching together two halves of the customer promise.

--- a/content/part-05/linking-crm-milestones/narratives/02-why-alignment-matters.md
+++ b/content/part-05/linking-crm-milestones/narratives/02-why-alignment-matters.md
@@ -1,0 +1,5 @@
+Speaker 1: Deals are often sold months before go-live. If the technical and support teams only find out at the kickoff meeting,
+change windows have to be negotiated under pressure and incidents feel like they come out of nowhere.
+
+Speaker 2: By wiring CRM stages into ITIL workflows, we move the conversation earlier. Risk assessments and approval gates can h
+appen before a contract is signed, and we stop promising delivery dates that the operations team cannot support.

--- a/content/part-05/linking-crm-milestones/narratives/03-anchor-points.md
+++ b/content/part-05/linking-crm-milestones/narratives/03-anchor-points.md
@@ -1,0 +1,6 @@
+Speaker 1: Let's map the major stages. When an opportunity is qualified, we already know which service catalogue items the custo
+mer expects.
+
+Speaker 2: Then the proposal stage triggers technical validation. Contract sent means we can draft the change record with a tent
+ative implementation window. Closed won should auto-create the ServiceNow handover ticket, and renewals prompt a review of exist
+ing incidents before pricing is finalised.

--- a/content/part-05/linking-crm-milestones/narratives/03-anchor-points.md
+++ b/content/part-05/linking-crm-milestones/narratives/03-anchor-points.md
@@ -1,6 +1,5 @@
-Speaker 1: Let's map the major stages. When an opportunity is qualified, we already know which service catalogue items the custo
-mer expects.
+Speaker 1: Let's map the major stages. When an opportunity is qualified, we already know which service catalogue items the customer expects.
 
-Speaker 2: Then the proposal stage triggers technical validation. Contract sent means we can draft the change record with a tent
-ative implementation window. Closed won should auto-create the ServiceNow handover ticket, and renewals prompt a review of exist
-ing incidents before pricing is finalised.
+Speaker 2: Then the proposal stage triggers technical validation. Contract sent means we can draft the change record with a tentative implementation window. Closed won should auto-create the ServiceNow handover ticket, and renewals prompt a review of existing incidents before pricing is finalised.
+
+Speaker 1: Picture CloudOps selling to MegaCorp. The moment the deal hits "Qualified," we double-check whether our monitoring service satisfies their audit checklist. By "Contract Sent," the change record draft already blocks a Friday night maintenance window so the CAB sees we're serious about stability.

--- a/content/part-05/linking-crm-milestones/narratives/04-triggering-change-records.md
+++ b/content/part-05/linking-crm-milestones/narratives/04-triggering-change-records.md
@@ -1,0 +1,4 @@
+Speaker 1: Automation helps here. As soon as the opportunity hits proposal, Salesforce can open a draft change record.
+
+Speaker 2: Right, and the solution engineer uploads architecture notes, proposed go-live dates and risk ratings. Synchronising t
+hat data to the CAB calendar ensures capacity planning happens before anyone signs the statement of work.

--- a/content/part-05/linking-crm-milestones/narratives/05-incident-workflows.md
+++ b/content/part-05/linking-crm-milestones/narratives/05-incident-workflows.md
@@ -1,0 +1,4 @@
+Speaker 1: Incident managers need more than a customer name. They need SLA tier, open projects, and escalation contacts.
+
+Speaker 2: That's why we embed CRM widgets into the incident form. When a ticket arrives, the responder can see if the customer 
+is in the middle of a cutover or approaching renewal, and page the right executive sponsors without leaving the console.

--- a/content/part-05/linking-crm-milestones/narratives/06-data-quality.md
+++ b/content/part-05/linking-crm-milestones/narratives/06-data-quality.md
@@ -1,0 +1,4 @@
+Speaker 1: All of this falls apart if the data is sloppy. We need consistent stage definitions and mandatory fields.
+
+Speaker 2: Exactly. Validation rules in Salesforce can block progression if risk assessments or service requirements are missing.
+ And when CAB decisions are attached directly to the opportunity record, compliance teams can audit the full trail.

--- a/content/part-05/linking-crm-milestones/narratives/07-collaboration-rituals.md
+++ b/content/part-05/linking-crm-milestones/narratives/07-collaboration-rituals.md
@@ -1,5 +1,3 @@
-Speaker 1: Process only works when the people rhythms support it. Weekly syncs between revenue operations and service managemen
-t keep the handoffs fresh.
+Speaker 1: Process only works when the people rhythms support it. Weekly syncs between revenue operations and service management keep the handoffs fresh.
 
-Speaker 2: And those reverse demos are powerful. When sales sees how incidents unfold, they appreciate why we need lead time and
- precise data. Shared dashboards prevent siloed conversations because everyone works from the same truth.
+Speaker 2: And those reverse demos are powerful. When sales sees how incidents unfold, they appreciate why we need lead time and precise data. Nothing wakes up a rep faster than a 3am incident recording where nobody knows which customer is affected. Shared dashboards prevent siloed conversations because everyone works from the same truth.

--- a/content/part-05/linking-crm-milestones/narratives/07-collaboration-rituals.md
+++ b/content/part-05/linking-crm-milestones/narratives/07-collaboration-rituals.md
@@ -1,0 +1,5 @@
+Speaker 1: Process only works when the people rhythms support it. Weekly syncs between revenue operations and service managemen
+t keep the handoffs fresh.
+
+Speaker 2: And those reverse demos are powerful. When sales sees how incidents unfold, they appreciate why we need lead time and
+ precise data. Shared dashboards prevent siloed conversations because everyone works from the same truth.

--- a/content/part-05/linking-crm-milestones/narratives/08-metrics.md
+++ b/content/part-05/linking-crm-milestones/narratives/08-metrics.md
@@ -1,0 +1,5 @@
+Speaker 1: We also need to measure whether the alignment is working. One metric is the percentage of closed deals that have comp
+lete change packages before the kick-off.
+
+Speaker 2: Another is MTTR. When incident responders get CRM context automatically, resolution times shrink. Customer satisfaction
+scores at renewal are a good lagging indicator, and retrospectives give us the qualitative feedback to keep iterating.

--- a/content/part-05/linking-crm-milestones/narratives/09-roles-and-careers.md
+++ b/content/part-05/linking-crm-milestones/narratives/09-roles-and-careers.md
@@ -1,0 +1,5 @@
+Speaker 1: This alignment creates interesting career paths. Revenue ops analysts learn ITSM language, while service transition ma
+nagers influence CRM design.
+
+Speaker 2: Platform engineers who integrate Salesforce with ServiceNow become highly sought-after. Someone starting as a junior C
+RM admin can specialise in ITSM integrations and move into service portfolio management over time.

--- a/content/part-05/linking-crm-milestones/narratives/09-roles-and-careers.md
+++ b/content/part-05/linking-crm-milestones/narratives/09-roles-and-careers.md
@@ -1,5 +1,3 @@
-Speaker 1: This alignment creates interesting career paths. Revenue ops analysts learn ITSM language, while service transition ma
-nagers influence CRM design.
+Speaker 1: This alignment creates interesting career paths. Revenue ops analysts learn ITSM language, while service transition managers influence CRM design.
 
-Speaker 2: Platform engineers who integrate Salesforce with ServiceNow become highly sought-after. Someone starting as a junior C
-RM admin can specialise in ITSM integrations and move into service portfolio management over time.
+Speaker 2: Platform engineers who integrate Salesforce with ServiceNow become highly sought-after. Someone starting as a junior CRM admin can stack Salesforce Administrator, ITIL Foundation and ServiceNow certifications, specialise in ITSM integrations and move into service portfolio management over time.

--- a/content/part-05/linking-crm-milestones/narratives/10-key-takeaway.md
+++ b/content/part-05/linking-crm-milestones/narratives/10-key-takeaway.md
@@ -1,0 +1,4 @@
+Speaker 1: The punchline is simple: CRM milestones should signal ITIL actions, not just revenue forecasting.
+
+Speaker 2: When sales, service and platform teams co-own those signals, customers experience a seamless journey from commitment 
+to steady-state operations. That's how we keep promises credible.

--- a/content/part-05/linking-crm-milestones/slides.md
+++ b/content/part-05/linking-crm-milestones/slides.md
@@ -31,6 +31,15 @@ essments and comms happen before a contract closes—protecting customer trust a
 
 ---
 
+## When the alignment breaks
+
+- **MegaCorp 2022** – deal closed without notifying change managers; go-live clashed with a data-centre freeze and cost 12 hours of downtime
+- **HealthcareCo** – missing renewal-to-incident review meant pricing ignored chronic SLA breaches and triggered legal escalation
+- **StartUp X** – marketing promised premium support tier but CRM never updated, so incidents paged the wrong on-call crew
+- Debrief every miss to update required fields, automation owners and CAB checklists
+
+---
+
 ## Triggering change records from the CRM
 
 - Create automation that opens a "pre-change" record when the stage reaches *Proposal*
@@ -58,12 +67,30 @@ essments and comms happen before a contract closes—protecting customer trust a
 
 ---
 
+## Integration pitfalls to watch
+
+- API users without least-privilege scopes lead to audit findings—lock them down with dedicated roles
+- Mismatched picklists cause automation to fail silently; institute nightly sync checks
+- Dual ownership of incident data (CRM vs ITSM) confuses escalation paths—publish a single-source-of-truth policy
+- Forgetting sandbox-to-prod deployment plans leaves integrations broken after releases; pair DevOps and admins on change reviews
+
+---
+
 ## Collaboration rituals
 
 - Weekly revenue-ops & service management sync to review upcoming milestones
 - Joint pipeline reviews focus on accounts entering change-heavy stages
 - Run "reverse demos" where ITIL teams show sales how incidents are triaged
 - Share an integrated dashboard: pipeline, change calendar, major incident log
+
+---
+
+## ROI modeling example
+
+- Input: $450k annual revenue at risk from change-related incidents, $120k integration project cost
+- Alignment reduces failed changes by 40%, cutting incident hours by 600 and avoiding $300k SLA penalties
+- Automation saves 8 FTE hours per deal cycle; across 40 deals equals 320 hours (~$48k) back to the teams
+- Payback <12 months with $228k net benefit plus compliance posture improvements
 
 ---
 
@@ -82,6 +109,17 @@ essments and comms happen before a contract closes—protecting customer trust a
 - **Service Transition Managers** translate change standards into CRM guidance
 - **Platform Engineers** build the integrations and monitor data quality
 - Early-career CRM admins can grow into ITSM integration specialists or service portfolio managers
+- Skill ladder: Salesforce Administrator → ITIL Foundation → ServiceNow System Admin → ITIL Practitioner/DevOps Institute certs
+- Pair hands-on integration projects with CAB participation to accelerate promotion readiness
+
+---
+
+## CAB meeting simulation
+
+- Scenario: Opportunity at *Proposal* stage requests expedited deployment for a banking client
+- CRM change checklist auto-populates risk, revenue impact and customer communication plan for the CAB agenda
+- Change manager quizzes sales on blackout dates; jointly agree to pilot in sandbox with staged rollout
+- Decision recorded in both CRM and ITSM, triggering follow-up tasks for documentation and customer briefing
 
 ---
 

--- a/content/part-05/linking-crm-milestones/slides.md
+++ b/content/part-05/linking-crm-milestones/slides.md
@@ -1,0 +1,93 @@
+---
+marp: true
+title: Linking CRM Milestones to ITIL Change and Incident Processes
+---
+
+# CRM Milestones & ITIL Alignment
+*Making revenue and service teams sync*
+
+### Learning objectives
+- Map Salesforce milestones to ITIL change and incident events
+- Identify collaboration moments between sales, service and platform teams
+- Define controls that keep customer promises and operational stability in sync
+
+---
+
+## Why this alignment matters
+
+Revenue teams promise outcomes to customers long before go-live. When those promises never reach service or platform teams, cha
+nge windows are missed and incident response looks uninformed. Aligning CRM stages with ITIL workflows means approvals, risk ass
+essments and comms happen before a contract closes—protecting customer trust and internal uptime.
+
+---
+
+## Anchor points across the lifecycle
+
+- **Qualified Opportunity** → service catalogue fit check, draft support model
+- **Proposal/Quote** → technical validation, early change assessment
+- **Contract Sent** → provisional change record with planned implementation window
+- **Closed Won** → kick-off in ServiceNow/ITSM, confirm handover package
+- **Renewal** → review live incidents, problem backlog and SLA trend reports
+
+---
+
+## Triggering change records from the CRM
+
+- Create automation that opens a "pre-change" record when the stage reaches *Proposal*
+- Require solution engineers to attach architecture diagrams and risk notes
+- Sync target implementation dates to the CAB calendar so availability is checked early
+- Use RACI fields to tag service owners, platform leads and vendor contacts
+
+---
+
+## Incident workflows informed by CRM data
+
+- Embed account health, SLA tier and escalation paths inside the incident form via API integration
+- Surface active projects or deployments linked to the account when the incident is logged
+- Flag high-value milestones (go-live, cutover, renewal) so major incidents auto-page the right leaders
+- Provide account teams with post-incident summaries that feed renewal conversations
+
+---
+
+## Keeping data clean and auditable
+
+- Standardise stage definitions and required fields for change-impact questions
+- Use validation rules to block stage progression if service requirements are blank
+- Timestamp approvals and attach CAB decisions within the CRM for compliance
+- Archive milestone-to-change links so auditors can trace commitments end-to-end
+
+---
+
+## Collaboration rituals
+
+- Weekly revenue-ops & service management sync to review upcoming milestones
+- Joint pipeline reviews focus on accounts entering change-heavy stages
+- Run "reverse demos" where ITIL teams show sales how incidents are triaged
+- Share an integrated dashboard: pipeline, change calendar, major incident log
+
+---
+
+## Metrics and continuous improvement
+
+- Track % of closed deals with complete change packages before go-live
+- Measure incident MTTR when CRM context is auto-synced versus manual lookup
+- Monitor customer satisfaction at renewals tied to well-managed change rollouts
+- Use retros to refine automation and handoff templates each quarter
+
+---
+
+## Roles and career pathways
+
+- **Revenue Operations Analysts** design field requirements and automation
+- **Service Transition Managers** translate change standards into CRM guidance
+- **Platform Engineers** build the integrations and monitor data quality
+- Early-career CRM admins can grow into ITSM integration specialists or service portfolio managers
+
+---
+
+## Key takeaway
+
+Treat CRM milestones as control points for ITIL change and incident readiness. When sales, delivery and support co-own the data,
+customers experience seamless transitions from promise to production stability.
+
+---

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/01-intro.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/01-intro.md
@@ -1,0 +1,5 @@
+Speaker 1: In this walkthrough we're putting ourselves in the shoes of a Salesforce account executive taking a deal from first t
+ouch to signature.
+
+Speaker 2: Instead of abstract theory, we'll follow a named customer, a real pipeline flow, and highlight the collaboration poin
+ts with solution engineering and service transition.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/02-scenario-setup.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/02-scenario-setup.md
@@ -1,0 +1,4 @@
+Speaker 1: Our company is CloudOps Solutions and the prospect is RiverBank, a regulated financial services firm.
+
+Speaker 2: That context matters. It means longer security reviews, change freezes around quarter-end, and a bigger cast of stake
+holders. We'll use Salesforce Lightning to keep the moving pieces under control.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/03-lead-capture.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/03-lead-capture.md
@@ -1,0 +1,4 @@
+Speaker 1: The journey starts with a marketing-generated lead. Priya Shah attended our DevOps compliance webinar.
+
+Speaker 2: We import her details, tag the industry, and create a follow-up task. Pausing the nurture emails prevents duplicate me
+ssaging while sales takes over.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/04-qualify-convert.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/04-qualify-convert.md
@@ -1,5 +1,3 @@
-Speaker 1: During the first call we confirm BANT—budget, authority, need, and timeline. Priya wants to cut incident-related chan
-ge failures in half before year-end.
+Speaker 1: During the first call we confirm BANT—budget, authority, need, and timeline. Priya wants to cut incident-related change failures in half before year-end.
 
-Speaker 2: Once qualified, we convert the lead. Salesforce creates the account, contact and opportunity records in one move. We 
-also assign our solution engineer and customer success partner so discovery is collaborative from day one.
+Speaker 2: Once qualified, we convert the lead. Salesforce creates the account, contact and opportunity records in one move. We also assign our solution engineer Sarah—she speaks fluent compliance—and our customer success partner Mike, who has yet to meet a regulatory framework he couldn't charm, so discovery is collaborative from day one.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/04-qualify-convert.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/04-qualify-convert.md
@@ -1,0 +1,5 @@
+Speaker 1: During the first call we confirm BANT—budget, authority, need, and timeline. Priya wants to cut incident-related chan
+ge failures in half before year-end.
+
+Speaker 2: Once qualified, we convert the lead. Salesforce creates the account, contact and opportunity records in one move. We 
+also assign our solution engineer and customer success partner so discovery is collaborative from day one.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/05-discovery-stage.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/05-discovery-stage.md
@@ -1,0 +1,4 @@
+Speaker 1: In discovery we document the current release process, incident history and compliance guardrails.
+
+Speaker 2: Salesforce Path guidance nudges us to attach agendas, meeting notes and stakeholder maps. The shared notes doc keeps s
+ales, engineering and service transition aligned on what we learn.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/05-discovery-stage.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/05-discovery-stage.md
@@ -1,4 +1,3 @@
 Speaker 1: In discovery we document the current release process, incident history and compliance guardrails.
 
-Speaker 2: Salesforce Path guidance nudges us to attach agendas, meeting notes and stakeholder maps. The shared notes doc keeps s
-ales, engineering and service transition aligned on what we learn.
+Speaker 2: Salesforce Path guidance nudges us to attach agendas, meeting notes and stakeholder maps. Priya mentions three production incidents last quarter during code releases, so we log that in the Pain Points field and flag it for our solution engineer to tackle in the technical demo. The shared notes doc keeps sales, engineering and service transition aligned on what we learn.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/06-solution-design.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/06-solution-design.md
@@ -1,0 +1,5 @@
+Speaker 1: When we shift to solution design, the opportunity stage moves to Solution Proposed. That means we have an architectur
+e diagram, value metrics and an initial change impact assessment.
+
+Speaker 2: We upload the proposal pack and trigger automation that opens a provisional ITIL change record with the target cutove
+r window. Cross-functional deal reviews keep legal, product and service teams in sync.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/07-proposal-negotiation.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/07-proposal-negotiation.md
@@ -1,0 +1,4 @@
+Speaker 1: In the proposal stage we generate the CPQ quote, lock pricing and document the SLA tier.
+
+Speaker 2: Compliance is key for RiverBank, so we attach data processing agreements and track security review status. Salesforce
+ approval flows handle discount or legal exceptions without endless email threads.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/07-proposal-negotiation.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/07-proposal-negotiation.md
@@ -1,4 +1,3 @@
 Speaker 1: In the proposal stage we generate the CPQ quote, lock pricing and document the SLA tier.
 
-Speaker 2: Compliance is key for RiverBank, so we attach data processing agreements and track security review status. Salesforce
- approval flows handle discount or legal exceptions without endless email threads.
+Speaker 2: Compliance is key for RiverBank, so we attach data processing agreements and track security review status. We also flag the primary competitor in the Opportunity Competitor related list and capture their differentiators in battle cards so marketing can feed us fresh talking points. Salesforce approval flows handle discount or legal exceptions without endless email threads.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/08-closing-handoff.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/08-closing-handoff.md
@@ -1,0 +1,4 @@
+Speaker 1: Once procurement signs off, we mark the deal Closed Won. That kicks off the downstream work.
+
+Speaker 2: Salesforce auto-creates the implementation project with all the proposal artifacts. Finance is alerted for invoicing,
+ customer success gets the onboarding checklist, and we document the mutual action plan so everyone knows the next steps.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/09-post-close.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/09-post-close.md
@@ -1,0 +1,5 @@
+Speaker 1: The opportunity record stays useful after the signature. We schedule 30, 60 and 90-day check-ins and link onboarding
+ tasks back to the account.
+
+Speaker 2: We also track early usage signals and customer health. That data feeds QBR prep, renewal campaigns and refinements to
+ our marketing personas.

--- a/content/part-05/salesforce-opportunity-walkthrough/narratives/10-key-takeaway.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/narratives/10-key-takeaway.md
@@ -1,0 +1,4 @@
+Speaker 1: The lesson is that managing an opportunity is about more than forecasting. It's an orchestration exercise.
+
+Speaker 2: When you capture clean data, bring the right teammates in early and align with delivery plans, you create a straight l
+ine from promise to value. That's how sales becomes a trusted advisor.

--- a/content/part-05/salesforce-opportunity-walkthrough/slides.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/slides.md
@@ -1,0 +1,102 @@
+---
+marp: true
+title: Salesforce Opportunity Walkthrough – Lead to Close
+---
+
+# Salesforce Opportunity Walkthrough
+*From curious lead to signed deal*
+
+### Learning objectives
+- Follow a practical Salesforce flow for progressing a B2B tech opportunity
+- Understand which fields and artifacts matter at each stage
+- See where sales, solution and service teams collaborate before close
+
+---
+
+## Scenario setup
+
+We play the role of an Account Executive at CloudOps Solutions, selling a managed DevOps platform. Our prospect is RiverBank, a
+ regional financial services firm modernising its release process. We'll use Salesforce Lightning to capture data, automate task
+s and coordinate with pre-sales and delivery teams.
+
+---
+
+## Step 1 – Capture the lead
+
+- Marketing imports RiverBank CTO Priya Shah from a webinar list
+- Lead record includes industry, company size, compliance needs
+- Auto-assigned to the enterprise sales queue with nurture emails paused
+- Initial task: call within 24 hours to confirm interest and challenges
+
+---
+
+## Step 2 – Qualify and convert
+
+- Discovery call confirms budget, authority, need and timeline (BANT)
+- Update lead status to *Qualified* and capture notes on incident pain points
+- Convert lead → create Account "RiverBank", Contact "Priya Shah", and Opportunity "RiverBank – DevOps Platform"
+- Assign solution engineer and customer success partner during conversion
+
+---
+
+## Step 3 – Discovery & stage progression
+
+- Opportunity enters *Discovery* stage with exit criteria: documented current toolchain, change cadence, regulatory constraints
+- Log discovery meeting tasks and attach call recordings
+- Create Salesforce Path guidance reminders for security questionnaires and stakeholder mapping
+- Kick off shared notes doc for sales, SE and service transition manager
+
+---
+
+## Step 4 – Solution design and change alignment
+
+- Move to *Solution Proposed* when architecture draft and success metrics are defined
+- Upload proposal deck, ROI model and draft change impact assessment
+- Trigger automation to open a provisional ITIL change record with target go-live window
+- Schedule internal deal review with product, legal and service delivery leads
+
+---
+
+## Step 5 – Proposal, negotiation and approvals
+
+- Generate formal quote via CPQ, capturing pricing, term length and SLA tier
+- Capture security review status and attach signed data processing agreements
+- Track executive sponsor commitment and procurement steps in opportunity fields
+- Use Salesforce approvals to route discount requests and contract exceptions
+
+---
+
+## Step 6 – Closing and handoff
+
+- Once procurement confirms, set stage to *Closed Won* and populate closed date and win reasons
+- Auto-create implementation project in PSA or ServiceNow with attached proposal artifacts
+- Notify finance for invoicing and customer success for onboarding cadence
+- Log final mutual action plan tasks to keep post-sale teams aligned
+
+---
+
+## Step 7 – Post-close follow-through
+
+- Monitor onboarding tasks via project dashboard and update opportunity follow-up field at 30/60/90 days
+- Capture customer health updates and initial usage metrics linked to the account
+- Schedule QBR and renewal reminder campaigns once the platform is live
+- Feed lessons learned back into marketing persona and playbooks
+
+---
+
+## Roles and growth paths
+
+- **Account Executive** orchestrates the opportunity and stakeholder management
+- **Solution Engineer** validates technical fit and risk mitigations
+- **Service Transition Manager** ensures ITIL change preparation and onboarding readiness
+- Skills gained—Salesforce automation, mutual plans, compliance coordination—set up progression into enterprise sales leadership
+or revenue operations
+
+---
+
+## Key takeaway
+
+Walking an opportunity from lead to close in Salesforce is about disciplined data capture, cross-functional coordination and ear
+ly alignment with delivery teams. Master these habits and you become the connective tissue between promise and value realization.
+
+---

--- a/content/part-05/salesforce-opportunity-walkthrough/slides.md
+++ b/content/part-05/salesforce-opportunity-walkthrough/slides.md
@@ -61,6 +61,7 @@ s and coordinate with pre-sales and delivery teams.
 
 - Generate formal quote via CPQ, capturing pricing, term length and SLA tier
 - Capture security review status and attach signed data processing agreements
+- Log competitors in the related list, note their strengths/risks, and trigger battle-card tasks for marketing support
 - Track executive sponsor commitment and procurement steps in opportunity fields
 - Use Salesforce approvals to route discount requests and contract exceptions
 
@@ -91,6 +92,7 @@ s and coordinate with pre-sales and delivery teams.
 - **Service Transition Manager** ensures ITIL change preparation and onboarding readiness
 - Skills gained—Salesforce automation, mutual plans, compliance coordination—set up progression into enterprise sales leadership
 or revenue operations
+- Career ladder: Salesforce Administrator certification → ITIL Foundation → ServiceNow System Admin or CAB participation for integration credibility
 
 ---
 


### PR DESCRIPTION
## Summary
- add slides and narrated scripts aligning CRM milestones with ITIL change and incident workflows for part 5
- create hands-on Salesforce opportunity walkthrough content from lead capture to closed-won with supporting narratives
- mark the corresponding Part 5 to-do items complete in TODO.md

## Testing
- not run (content-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ced527b6748325bb6d11d2344b14fb