### PR TITLE
Outline objectives for start-up IT module

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -101,7 +101,7 @@ Use the checklist below to track progress for each part.
 - [x] Create quiz questions
 
 #### Part 6 – Start-ups & Small-Biz IT
-- [ ] Outline objectives and key topics
+- [x] Outline objectives and key topics
 - [ ] Create to-do list items for each topic to draft slides and write narratives
 - [ ] Create quiz questions
 

--- a/content/part-06/outline.md
+++ b/content/part-06/outline.md
@@ -2,6 +2,10 @@
 
 This part highlights how lean start-ups and small businesses bootstrap their IT stack, adopt lightweight tools, and scale processes as they grow.
 
+> **Opening hook:** "Sarah just closed her seed round and has six weeks to hire 15 people. Her entire IT estate is Gmail, Slack, and a hope. What could possibly go wrong?"
+
+Use Sarah's story as the running narrative, revisiting her decisions and panic moments as the session progresses.
+
 **Why This Matters**
 
 Tiny teams need enterprise-grade outcomes without enterprise budgets. Understanding the scrappy toolchains, compliance shortcuts and scaling pain points of founder-led companies prepares graduates to advise or join them with realistic expectations.
@@ -14,19 +18,42 @@ Tiny teams need enterprise-grade outcomes without enterprise budgets. Understand
 - Recommend scalable processes for support, change and vendor management as headcount expands.
 - Translate investor expectations (runway, burn, resilience) into pragmatic IT roadmaps.
 
-## Key Topics
+## Session Flow & Key Topics
 
-- Incorporating the company and standing up core services: domain registration, productivity suites, device procurement.
-- Choosing lightweight SaaS for collaboration, ticketing, CRM and finance, plus when to graduate to enterprise platforms.
-- Shadow IT and no-code/low-code experimentation: empowering teams without creating chaos.
-- Security baselines on a shoestring: MDM-lite, password managers, zero-trust defaults and outsourced SOC options.
-- Budgeting and FinOps for start-ups: usage monitoring, cloud credits, and forecasting burn tied to tooling.
-- Working with fractional CTOs, virtual CIOs and MSPs to cover skill gaps.
-- Preparing for investor due diligence: policies, documentation and metrics that demonstrate operational maturity.
-- Scaling support processes from "ask the founder" to structured help desks and knowledge bases.
-- Business continuity planning for small teams: backups, incident communication templates and vendor redundancy.
-- Regional compliance considerations (privacy, payments, data residency) when selling globally from day one.
-- Building lightweight vendor management rhythms for outsourced development, marketing and support partners.
+### Day 0–90: Ship Something Without Lighting Money on Fire
+
+- Incorporating the company and standing up core services: domain registration, productivity suites, device procurement, and "CEO learns DNS the hard way" cautionary tale.
+- Cloud vs. on-premise decisions: free tiers across AWS, Azure, GCP, when to stay serverless versus spinning up containers, and how startup credits influence the call.
+- Shadow IT and no-code/low-code experimentation: empowering teams without creating chaos, with humour about "the intern who accidentally made everyone a Slack admin".
+- Security baselines on a shoestring: MDM-lite, password managers, zero-trust defaults and outsourced SOC options—"have you tried turning it off and on again" evolves into lightweight monitoring dashboards.
+- Remote-first reality check: device shipping, remote onboarding/offboarding, and managing a globally distributed, contractor-heavy workforce from day one.
+- Pre-seed tool stack example ($200/month): Google Workspace, Slack, Notion, 1Password, Airtable plus context on when Sarah should resist enterprise upsell.
+- Interactive checklist: "Day-zero startup IT assessment" covering identity, endpoints, backups and security toggles.
+
+### Series A: Organise the Chaos Before Investors Ask Awkward Questions
+
+- Choosing lightweight SaaS for collaboration, ticketing, CRM and finance, plus when to graduate to enterprise platforms; include "The great Zoom-to-Teams migration of 2023" mini-case.
+- Budgeting and FinOps for start-ups: usage monitoring, cloud credits, forecasting burn tied to tooling, and an exercise calculating total monthly stack spend.
+- Legal & compliance reality check: lawyers meeting DevOps on SOC 2, ISO 27001 timelines, open source licence compliance (GPL, Apache, MIT) and "Data privacy by design when you're moving fast".
+- Working with fractional CTOs, virtual CIOs and MSPs to cover skill gaps, highlighting vendor relationship humour ("promised the moon, delivered a paper airplane").
+- Remote-first talent logistics at scale: standardising equipment, automating access reviews, and preparing for global payroll/benefits integrations.
+- Series A tool stack example (~$2K/month): Add Okta, Zoom, Jira, AWS credits, compliance tooling (Drata, Vanta) and compare serverless vs. container costs.
+- Practical exercise: mock vendor evaluation using real SaaS pricing pages and "explain to the CEO why backups cost money" role-play.
+
+### Series B+: Become the Enterprise Without Losing the Soul
+
+- Preparing for investor due diligence: sample security questionnaires, "red flags that kill deals" stories, and mapping policies to board expectations.
+- Scaling support processes from "ask the founder" to structured help desks, knowledge bases and ITSM (introduce ServiceNow vs. Jira Service Management trade-offs).
+- Business continuity planning for small teams: backups, incident communication templates and vendor redundancy—"the night our MongoDB crashed" war story.
+- Regional compliance considerations (privacy, payments, data residency) when selling globally, plus data governance humour (from "personal Dropbox" to enterprise retention policies).
+- Building lightweight vendor management rhythms for outsourced development, marketing and support partners, including the Stripe vs. build-your-own payments decision.
+- Series B enterprise migration stack (~$20K/month): Salesforce, ServiceNow, enterprise identity, SIEM, contract lifecycle management, with cost calculator worksheet.
+- Guest speaker ideas: fractional CTO, startup-focused MSP account manager, VC diligence lead to discuss real expectations.
+
+### Capstone: "Red Team Your Friend's Startup"
+
+- Group exercise to critique a sample startup's tooling, run a security incident drill for a 15-person team, and map Sarah's company to the three-stage maturity model.
+- Encourage participants to bring their own due diligence questions and create a take-home remediation roadmap.
 
 ## Job Roles Focus
 
@@ -59,3 +86,17 @@ Tiny teams need enterprise-grade outcomes without enterprise budgets. Understand
   - *Career progression:* Moves into RevOps leadership, product operations or platform product management.
 
 Expect start-ups to allocate only a handful of headcount to IT until Series B, so professionals must influence cross-functional peers and justify tooling investments with data.
+
+## Supporting Materials & Resources
+
+- Startup IT assessment checklist (Google Sheet) covering identity, device, data and compliance baselines.
+- Cost calculator worksheet modelling pre-seed, Series A and Series B tooling spend scenarios.
+- Sample investor security questionnaire with annotated "good" and "red flag" responses.
+- Template for remote onboarding/offboarding logistics, including shipping providers and asset-tracking tips.
+- Reading list: vendor case studies (Stripe, Zoom, ServiceNow), compliance playbooks, and blogs from startup-focused MSPs.
+
+## Conversation & Humour Beats
+
+- Thread Sarah's narrative through each stage: "Once you've sorted the domain and email, the next founder panic is…"
+- Light-touch jokes: the four stages of startup IT (Panic, Google, Slack someone, hire a consultant) and vendor pricing shocks.
+- Use real missteps (intern Slack admin mishap, MongoDB outage) to humanise lessons while reinforcing best practices.

--- a/content/part-06/outline.md
+++ b/content/part-06/outline.md
@@ -12,6 +12,7 @@ Tiny teams need enterprise-grade outcomes without enterprise budgets. Understand
 - Compare the cost and control trade-offs between DIY administration, managed service providers and fractional CTOs.
 - Prioritise cybersecurity, compliance and business continuity controls appropriate to each growth stage.
 - Recommend scalable processes for support, change and vendor management as headcount expands.
+- Translate investor expectations (runway, burn, resilience) into pragmatic IT roadmaps.
 
 ## Key Topics
 
@@ -25,12 +26,36 @@ Tiny teams need enterprise-grade outcomes without enterprise budgets. Understand
 - Scaling support processes from "ask the founder" to structured help desks and knowledge bases.
 - Business continuity planning for small teams: backups, incident communication templates and vendor redundancy.
 - Regional compliance considerations (privacy, payments, data residency) when selling globally from day one.
+- Building lightweight vendor management rhythms for outsourced development, marketing and support partners.
 
 ## Job Roles Focus
 
-- **IT Generalist / Founding Engineer** – often combines help desk, sysadmin and security duties in pre-Series A firms. Typically mid-level technologists comfortable wearing many hats; great for adaptable, curious personalities who enjoy ambiguity. Progression into engineering leadership or specialised architecture roles as the company scales.
-- **Fractional CTO / Virtual CIO** – senior advisors parachuting in a few days per month to guide technical strategy and governance. Requires seasoned leadership background and consultative communication skills; suits strategic thinkers who like varied portfolios. Often transition into board roles or full-time CTO positions once product-market fit is reached.
-- **MSP Account Manager & Field Technician** – external partners delivering managed endpoints, networking and support. Roles span entry-level technicians through senior service delivery managers. Ideal for service-minded problem solvers; provides pathways into cybersecurity, cloud engineering or customer success.
-- **Operations or Revenue Platform Owner** – non-traditional IT roles embedded in marketing, sales or finance teams to administer SaaS stacks. Usually start as power users or business analysts; great for detail-oriented collaborators. Career trajectory can lead to RevOps leadership or product operations management.
+- **IT Generalist / Founding Engineer**
+  - *Typical seniority:* Mid-level technologists or career-switching engineers comfortable wearing many hats until Series A.
+  - *Entry pathways:* Often ex-help desk or DevOps practitioners, bootcamp graduates or technical co-founders formalising IT.
+  - *Personality traits:* Curious problem solvers who enjoy ambiguity, rapid learning and hands-on experimentation.
+  - *Org proportion:* Usually 1 FTE covering 30–80 staff, supplemented by contractors for specialised needs.
+  - *Career progression:* Grows into head of IT, platform engineering or security leadership as the company scales.
+
+- **Fractional CTO / Virtual CIO**
+  - *Typical seniority:* Seasoned director+ leaders lending strategic oversight a few days per month.
+  - *Entry pathways:* Alumni of enterprise architecture, consultancy or repeat founders shifting into advisory work.
+  - *Personality traits:* Strategic communicators who can coach executives, prioritise investments and manage vendors.
+  - *Org proportion:* Engaged by ~25% of venture-backed start-ups pre-Series B, usually alongside 0–1 internal IT hires.
+  - *Career progression:* Transition into board seats, interim CTO roles or boutique advisory practices.
+
+- **MSP Account Manager & Field Technician**
+  - *Typical seniority:* Mix of entry-level technicians for on-site work and senior service delivery managers coordinating SLAs.
+  - *Entry pathways:* TAFE/apprenticeship programs, CompTIA pathways or internal promotions from service desk teams.
+  - *Personality traits:* Service-minded troubleshooters who thrive on variety and customer relationship management.
+  - *Org proportion:* MSP partners often contribute the equivalent of 0.5–2 FTE across 60–150 endpoints.
+  - *Career progression:* Pathways into cybersecurity analyst, cloud engineer or customer success leader roles within the MSP.
+
+- **Operations or Revenue Platform Owner**
+  - *Typical seniority:* Business analysts or ops managers stepping into SaaS administration duties.
+  - *Entry pathways:* Power users of CRM/finance tools, RevOps professionals, or former project coordinators.
+  - *Personality traits:* Detail-oriented collaborators who translate business requirements into system configurations.
+  - *Org proportion:* Typically 1 role per 40–60 go-to-market staff, often dual-hatted with finance or marketing ops.
+  - *Career progression:* Moves into RevOps leadership, product operations or platform product management.
 
 Expect start-ups to allocate only a handful of headcount to IT until Series B, so professionals must influence cross-functional peers and justify tooling investments with data.


### PR DESCRIPTION
## Summary
- expand the Part 6 outline with investor-aligned objectives and additional key topic coverage
- provide detailed job role profiles including seniority, entry routes, personality traits, proportions and progression
- mark the Part 6 outline task as completed in the project to-do list

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d125af05ec8325a9c6a188ffb525bd