### PR TITLE
Add FOSS licensing slides and narratives

### DIFF
--- a/content/part-07/foss-licensing-options/narratives/01-intro.md
+++ b/content/part-07/foss-licensing-options/narratives/01-intro.md
@@ -1,0 +1,6 @@
+# Why licensing matters for open-source
+
+Free and open-source software (FOSS) licences translate community values into legally enforceable rules. Without them, collaborat
+ion would rely on vague goodwill and expose contributors to liability. Licences are what allow organisations to adopt community-
+built code with confidence, knowing the obligations they are accepting. They also give developers a say in how their work can be
+used commercially, redistributed or integrated into proprietary platforms.

--- a/content/part-07/foss-licensing-options/narratives/02-permissive.md
+++ b/content/part-07/foss-licensing-options/narratives/02-permissive.md
@@ -1,0 +1,5 @@
+# Permissive licences: flexibility with light obligations
+
+Permissive licences such as MIT, BSD and Apache 2.0 grant broad rights to use, modify and redistribute code with few restrictio
+ns. Typical conditions include preserving copyright notices and providing attribution. Apache 2.0 adds an explicit patent licenc
+e and retaliation clause, which reassures enterprise adopters. Because these licences allow closed-source derivatives, they are popular with start-ups building commercial services, vendor integration teams and digital agencies that need to embed open libraries into client solutions.

--- a/content/part-07/foss-licensing-options/narratives/03-copyleft.md
+++ b/content/part-07/foss-licensing-options/narratives/03-copyleft.md
@@ -1,0 +1,5 @@
+# Copyleft licences: reciprocity to sustain openness
+
+Copyleft licences like GPLv3, LGPL and AGPL require that derivative works remain under the same licence when distributed. This "
+share alike" obligation ensures improvements flow back to the community, which is why large public-sector platforms and non-pro
+fit foundations often adopt copyleft terms. Teams must pay attention to how software is delivered: providing compiled binaries, offering SaaS access or linking libraries dynamically each triggers different obligations. Product managers and release engineers should keep an inventory of components to avoid accidental licence conflicts during builds.

--- a/content/part-07/foss-licensing-options/narratives/04-choosing.md
+++ b/content/part-07/foss-licensing-options/narratives/04-choosing.md
@@ -1,0 +1,4 @@
+# Matching licences to organisational strategy
+
+Selecting a licence is a cross-functional decision. Open-source program office (OSPO) managers weigh how openness supports marke
+t adoption, while legal counsel checks compatibility with existing commercial agreements. Security engineers assess whether the licence terms align with disclosure policies and vulnerability management workflows. Early-stage contributors often default to permissive licences for visibility, but social enterprises and civic technology teams may prefer copyleft to preserve community benefits. Document the rationale, involve stakeholders early and revisit choices as the project evolves.

--- a/content/part-07/foss-licensing-options/narratives/05-compliance.md
+++ b/content/part-07/foss-licensing-options/narratives/05-compliance.md
@@ -1,0 +1,5 @@
+# Staying compliant in practice
+
+Maintaining compliance requires disciplined processes. Developer advocates teach engineers how to attribute dependencies within 
+documentation and user interfaces. Build engineers automate software bill of materials (SBOM) generation to prove which licence
+s are in use. Regular audits catch issues like missing source code offers for GPL components or forgotten NOTICE files for Apache libraries. Entry-level roles often start with these inventory and documentation tasks, building expertise that can lead to OSPO leadership or specialist counsel careers.

--- a/content/part-07/foss-licensing-options/narratives/06-takeaway.md
+++ b/content/part-07/foss-licensing-options/narratives/06-takeaway.md
@@ -1,0 +1,3 @@
+# Key takeaway
+
+Thoughtful licence selection is a strategic lever. It signals how you invite collaboration, protect contributors and align with Indigenous data sovereignty commitments when projects intersect with cultural knowledge. Teams that understand these obligations can design respectful contribution models and sustain long-term trust with communities and partners.

--- a/content/part-07/foss-licensing-options/slides.md
+++ b/content/part-07/foss-licensing-options/slides.md
@@ -1,0 +1,49 @@
+---
+marp: true
+title: FOSS Licensing Options and Obligations
+---
+
+# FOSS Licensing Choices
+*Picking the right licence for your project*
+
+---
+
+## Why licences matter
+- Define how code can be used, shared and monetised
+- Protect contributors and organisations from legal risk
+- Shape community expectations and collaboration norms
+
+---
+
+## Permissive licences (MIT, Apache 2.0)
+- Allow reuse with minimal obligations
+- Require attribution and licence notice retention
+- Favoured by start-ups, vendor platforms and integration partners
+
+---
+
+## Copyleft licences (GPL family)
+- Derivative works must remain open-source
+- Trigger "share alike" obligations on distribution of binaries
+- Common in infrastructure maintained by foundations and public agencies
+
+---
+
+## Choosing for your context
+- Align licence with business model, funding and compliance needs
+- Consider third-party code compatibility and patent clauses
+- Involve legal counsel, community tech-leads and product managers early
+
+---
+
+## Career pathways & responsibilities
+- Roles: Open-source program office (OSPO) managers, developer advocates, legal counsels
+- Entry routes: community contributions, compliance internships, dual STEM-law studies
+- Growth: progress to OSPO director or head of developer relations safeguarding ecosystem health
+
+---
+
+## Key takeaway
+Intentional licence selection balances openness, obligations and long-term sustainability.
+
+---


### PR DESCRIPTION
## Summary
- add Marp slide deck introducing key FOSS licence families and selection guidance
- provide narrative scripts covering permissive vs copyleft obligations and compliance practices
- highlight relevant career pathways and responsibilities linked to open-source licensing decisions

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d4f7f9a7c08325bf043b8229038ad3