### PR TITLE
Add Māori data sovereignty case study content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -110,7 +110,7 @@ Use the checklist below to track progress for each part.
 - [x] Create to-do list items for each topic to draft slides and write narratives
   - [x] Draft slides and narrative: FOSS licensing options and obligations (e.g. MIT, GPL, Apache)
   - [x] Draft slides and narrative: Community governance structures from single maintainer to foundations
-  - [ ] Draft slides and narrative: Maori case study highlighting Indigenous data sovereignty in action
+  - [x] Draft slides and narrative: Maori case study highlighting Indigenous data sovereignty in action
   - [ ] Draft slides and narrative: Balancing openness with cultural safety and responsible data sharing
   - [ ] Draft slides and narrative: The “community tech-lead” role and career pathways in open-source projects
 - [ ] Create quiz questions

--- a/content/part-07/maori-case-study/narratives/01-intro.md
+++ b/content/part-07/maori-case-study/narratives/01-intro.md
@@ -1,0 +1,3 @@
+Speaker 1: We wanted a case study that shows Indigenous communities leading their own digital futures, not being passive data subjects. Te Hiku Media is perfect because it’s iwi-owned, rooted in te ao Māori values and has built genuinely world-class AI tools while keeping sovereignty over the language assets.
+
+Speaker 2: Exactly. Their work illustrates that “open” doesn’t have to mean “public domain.” They use openness strategically—sharing with whānau, iwi partners and trusted researchers—while still protecting taonga. It gives us a concrete example of cultural protocols shaping a modern machine learning program.

--- a/content/part-07/maori-case-study/narratives/02-why-te-hiku.md
+++ b/content/part-07/maori-case-study/narratives/02-why-te-hiku.md
@@ -1,0 +1,3 @@
+Speaker 1: The organisation started as an iwi radio network in the Far North. Because they’ve been recording kaumātua voices for decades, they hold archives that Silicon Valley can’t replicate. When tech giants offered compute credits in exchange for the data, Te Hiku pushed back—they wanted partnership, not extraction.
+
+Speaker 2: Right, and that refusal is significant. Instead of chasing the fastest growth, they prioritised mana motuhake—self-determination. They sought funding from Māori trusts and philanthropies aligned with language revitalisation. That let them set terms before letting anyone access the corpus.

--- a/content/part-07/maori-case-study/narratives/03-kaupapa-foundations.md
+++ b/content/part-07/maori-case-study/narratives/03-kaupapa-foundations.md
@@ -1,0 +1,3 @@
+Speaker 1: Their governance model is anchored by the Kaitiakitanga licence, which literally says the data is a treasure held in trust for present and future iwi members. Any partner has to demonstrate reciprocity and cultural safety before touching the language assets.
+
+Speaker 2: And that’s backed by practice. They run hui where linguists, kaumātua and technologists review project proposals together. If whānau aren’t convinced the outcomes will uplift communities, the project pauses until the concerns are resolved. That blend of tikanga and agile delivery is what keeps sovereignty intact.

--- a/content/part-07/maori-case-study/narratives/04-building-corpus.md
+++ b/content/part-07/maori-case-study/narratives/04-building-corpus.md
@@ -1,0 +1,3 @@
+Speaker 1: The recording sprint they ran in 2019 is legendary—community members lined up to donate sentences in kura, marae and community centres. They paired each session with kai and cultural briefings so people understood where their voices would go.
+
+Speaker 2: The tech team then built a custom labeling tool because mainstream platforms couldn’t handle dialect nuances. They co-designed prompts with linguists to capture dialectical diversity, not just “standard” te reo. Contributors kept moral rights and could revoke samples, which is unheard of in most corporate datasets.

--- a/content/part-07/maori-case-study/narratives/05-tech-stack.md
+++ b/content/part-07/maori-case-study/narratives/05-tech-stack.md
@@ -1,0 +1,3 @@
+Speaker 1: From a technical perspective, they forked Mozilla Common Voice to jump-start infrastructure but stripped anything that conflicted with Māori governance. Storage sits in AWS Auckland zones with encryption keys controlled by Te Hiku, and every data access is logged for auditing by the board.
+
+Speaker 2: The roles are interesting too. They formalised “data kaitiaki” positions—people fluent in te reo who also understand privacy law. These staff sign off on data queries and review model outputs for cultural harm. It’s a career path that blends community leadership with product management skills.

--- a/content/part-07/maori-case-study/narratives/06-negotiating.md
+++ b/content/part-07/maori-case-study/narratives/06-negotiating.md
@@ -1,0 +1,3 @@
+Speaker 1: When global vendors came knocking, Te Hiku insisted on memoranda of understanding that detailed reciprocity. That included commitments to fund language revitalisation, keep infrastructure in Aotearoa and allow Te Hiku to veto secondary uses.
+
+Speaker 2: They also built tikanga clauses into the contracts—staff had to attend cultural safety training, and models couldn’t be repurposed for surveillance. Every partnership was staged with opt-out checkpoints so the community could walk away if promises were broken.

--- a/content/part-07/maori-case-study/narratives/07-outcomes.md
+++ b/content/part-07/maori-case-study/narratives/07-outcomes.md
@@ -1,0 +1,3 @@
+Speaker 1: The tangible results are huge. Automated transcription now captures iwi radio archives in hours instead of months, and whānau can search recordings for tīpuna names. The speech models achieved massive accuracy gains because they were trained on dialect-specific data.
+
+Speaker 2: Plus, the wider Indigenous tech movement took notice. Te Mana Raraunga referenced Te Hiku’s licensing approach when drafting national Māori data governance principles. Alumni from the project have moved into senior roles across government, iwi corporations and platform co-ops.

--- a/content/part-07/maori-case-study/narratives/08-takeaways.md
+++ b/content/part-07/maori-case-study/narratives/08-takeaways.md
@@ -1,0 +1,3 @@
+Speaker 1: So what should our learners copy from this? First, invest in cultural authority—make sure kaumātua, elders or cultural experts are leading alongside engineers. Second, treat licences as living documents that express consent and reciprocity, not just legal fine print.
+
+Speaker 2: And build career ladders. Roles like data kaitiaki, Indigenous product managers and kaupapa-aligned cybersecurity leads should have progression into senior leadership. Success metrics need to include community benefit and language vitality, otherwise the tech will drift away from its purpose.

--- a/content/part-07/maori-case-study/slides.md
+++ b/content/part-07/maori-case-study/slides.md
@@ -1,0 +1,65 @@
+---
+marp: true
+title: Māori Data Sovereignty in Practice
+---
+
+# Te Hiku Media Case Study
+*Community-led AI that keeps te reo Māori under Māori control*
+
+---
+
+## Why Te Hiku?
+- Iwi-owned broadcaster headquartered in Kaitaia, Aotearoa
+- Mission: revitalise te reo Māori through digital storytelling
+- Built voice-tech assets after decades of community archiving
+- Faced pressure from Big Tech to share language corpora for free
+
+---
+
+## Kaupapa Māori foundations
+- Guidance from Te Hiku's kaumātua and Kaitiakitanga licence
+- Data treated as taonga; consent grounded in whakapapa obligations
+- Governance board spans iwi leaders, technologists and legal advisors
+- Community hui confirm priorities before any tech deployment
+
+---
+
+## Building the language corpus
+- Collected 300,000+ sentences via community recording campaigns
+- Created Papakupu (lexicon) and automated speech recognition models
+- Engineers partnered with linguists and cultural advisors on prompts
+- Contributors retain rights; licence restricts extractive reuse
+
+---
+
+## Tech stack and roles
+- Product team: ML engineers, data stewards, cultural advisors, privacy counsel
+- Tooling: Mozilla Common Voice forks, bespoke labeling apps, AWS-hosted storage
+- Security: region-limited S3 buckets, auditable access logs, regular tikanga audits
+- Pathways: internships for rangatahi, upskilling iwi staff into data governance roles
+
+---
+
+## Negotiating with external partners
+- Declined offers from major cloud vendors lacking cultural safeguards
+- Established memoranda outlining reciprocity, local hosting and revenue sharing
+- Required vendors to sign tikanga training clauses and Māori IP protections
+- Used staged pilots with opt-out checkpoints and independent oversight
+
+---
+
+## Outcomes and impact
+- Delivered production-ready te reo speech-to-text with major word error rate reductions
+- Provided iwi radio partners with automation for archiving oral histories
+- Set precedent adopted by Te Mana Raraunga for Indigenous data licences
+- Elevated Māori technologists into senior data governance leadership
+
+---
+
+## Takeaways for practitioners
+- Embed cultural authority in every technical milestone
+- Budget for roles that bridge tech and tikanga; promote to product leadership
+- Use Indigenous-led licences to operationalise consent and reciprocity
+- Measure success via community benefit, not just model accuracy
+
+---


### PR DESCRIPTION
## Summary
- add slide deck for the Te Hiku Media Māori data sovereignty case study in Part 7
- provide supporting dual-speaker narration scripts that emphasise tikanga-led governance, technical execution, and career pathways
- mark the corresponding to-do list item complete

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d64e111630832593bb499a721093f3