### PR TITLE
Add Part 7 cultural safety content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -111,7 +111,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: FOSS licensing options and obligations (e.g. MIT, GPL, Apache)
   - [x] Draft slides and narrative: Community governance structures from single maintainer to foundations
   - [x] Draft slides and narrative: Maori case study highlighting Indigenous data sovereignty in action
-  - [ ] Draft slides and narrative: Balancing openness with cultural safety and responsible data sharing
+  - [x] Draft slides and narrative: Balancing openness with cultural safety and responsible data sharing
   - [ ] Draft slides and narrative: The “community tech-lead” role and career pathways in open-source projects
 - [ ] Create quiz questions
 

--- a/content/part-07/balancing-openness-cultural-safety/narratives/01-intro.md
+++ b/content/part-07/balancing-openness-cultural-safety/narratives/01-intro.md
@@ -1,0 +1,3 @@
+Speaker 1: When we say "open" in tech circles, people assume GitHub repos and creative commons everything. But for Indigenous communities, openness is negotiated, relational and grounded in tikanga. Our goal here is to show how you can invite collaboration without handing over guardianship of taonga.
+
+Speaker 2: Right, and it’s not just an ethical stance—it’s a strategic one. Communities want to drive impact from language archives, climate data or health studies, yet they’ve seen extractive research hollow trust. Balancing openness with cultural safety means designing processes that answer "who benefits?" and "who decides?" before a single CSV is shared.

--- a/content/part-07/balancing-openness-cultural-safety/narratives/02-sovereignty-frameworks.md
+++ b/content/part-07/balancing-openness-cultural-safety/narratives/02-sovereignty-frameworks.md
@@ -1,0 +1,3 @@
+Speaker 1: Frameworks like CARE and OCAP® give teams language to operationalise sovereignty. They flip the script from FAIR’s "make everything findable" to "how does this data deliver collective benefit, and who retains authority to say no?"
+
+Speaker 2: Exactly. When you cite UNDRIP Articles 18 and 31 in an agreement, you’re grounding decisions in international law that recognises cultural expressions as living knowledge. That empowers community tech-leads to slow down eager researchers and convene hui before any export happens.

--- a/content/part-07/balancing-openness-cultural-safety/narratives/03-consent-context.md
+++ b/content/part-07/balancing-openness-cultural-safety/narratives/03-consent-context.md
@@ -1,0 +1,3 @@
+Speaker 1: Consent isn’t a one-off signature; it’s an ongoing conversation. We’re recommending teams define sensitivity tiers so elders can differentiate between language-learning clips that can go to schools versus karakia that never leave the marae.
+
+Speaker 2: And document the stories behind the data. Provenance notes, cultural narratives and explicit usage boundaries travel with the dataset so future analysts understand the tikanga context. That’s how you avoid someone training a model on sacred audio because they only saw a file name.

--- a/content/part-07/balancing-openness-cultural-safety/narratives/04-access-governance.md
+++ b/content/part-07/balancing-openness-cultural-safety/narratives/04-access-governance.md
@@ -1,0 +1,3 @@
+Speaker 1: Tiered portals and review boards are how you translate those principles into day-to-day decisions. Whānau get first access, then trusted researchers who have gone through cultural briefings and signed reciprocal data-sharing agreements.
+
+Speaker 2: Governance lives in the paperwork too—MOUs that spell out kaitiaki roles, dispute resolution and benefit-sharing. Add Traditional Knowledge labels so licences travel with files, and insist partner institutions appoint liaison staff accountable back to the tribal council.

--- a/content/part-07/balancing-openness-cultural-safety/narratives/05-technical-safeguards.md
+++ b/content/part-07/balancing-openness-cultural-safety/narratives/05-technical-safeguards.md
@@ -1,0 +1,3 @@
+Speaker 1: People sometimes assume cultural safety is just policy, but the tech stack matters. Attribute-based access control lets you honour roles and protocols, and audit logs show exactly who downloaded which clip and when.
+
+Speaker 2: Pair that with encryption keys controlled by community stewards and monitoring for unusual usage. If someone suddenly scrapes thousands of files, alerts fire and the licence can be paused while you convene a restorative hui. Technology becomes a guardian alongside people.

--- a/content/part-07/balancing-openness-cultural-safety/narratives/06-roles-pathways.md
+++ b/content/part-07/balancing-openness-cultural-safety/narratives/06-roles-pathways.md
@@ -1,0 +1,3 @@
+Speaker 1: The roles slide shows this isn’t a solo act. You need cultural advisors sitting with engineers, and data stewards who can translate tikanga into access policies. Typically it’s one cultural lead per squad and a steward overseeing three to five partnerships.
+
+Speaker 2: Career-wise, we’re seeing interns from iwi digital hubs grow into community tech-leads, while policy analysts pivot into Chief Data Steward roles. The common traits are relational intelligence, patience and the ability to negotiate between community expectations and platform roadmaps.

--- a/content/part-07/balancing-openness-cultural-safety/narratives/07-scenario-takeaway.md
+++ b/content/part-07/balancing-openness-cultural-safety/narratives/07-scenario-takeaway.md
@@ -1,0 +1,3 @@
+Speaker 1: The scenario is intentionally practical. A university wants to add iwi audio to an open corpus, but they first have to produce a CARE-aligned impact statement and show how whānau benefit. Access is time-bound and requires reporting back in te reo Māori.
+
+Speaker 2: And there’s accountability—breaches trigger suspension, a restorative hui and potentially pulling derivative models. That’s the message: openness isn’t the absence of control, it’s shared responsibility with cultural governance setting the guardrails.

--- a/content/part-07/balancing-openness-cultural-safety/slides.md
+++ b/content/part-07/balancing-openness-cultural-safety/slides.md
@@ -1,0 +1,79 @@
+---
+marp: true
+title: Balancing Openness with Cultural Safety and Responsible Data Sharing
+---
+
+# Balancing Openness & Cultural Safety
+*Sharing knowledge without giving away guardianship*
+
+---
+
+## The tension we manage
+- Communities want visibility for their stories, research wants data, and platforms default to "public"
+- Cultural safety requires respecting protocols, whakapapa and the right to say "not now"
+- Openness is a spectrum: open to whom, for what purpose, and under whose authority?
+- Treat each dataset as taonga first, asset second
+
+---
+
+## Indigenous data sovereignty principles
+- CARE (Collective benefit, Authority to control, Responsibility, Ethics) complements FAIR for culturally grounded projects
+- OCAP® (Ownership, Control, Access, Possession) affirms First Nations governance of data lifecycles
+- UNDRIP Articles 18 & 31 underpin community decision-making over cultural expressions
+- Apply tikanga-led approval processes before any data leaves community servers
+
+---
+
+## Consent & context guardrails
+- Gain informed, ongoing consent—include language about derivative uses and AI training
+- Classify sensitivity tiers: open educational, community-restricted, sacred/closed
+- Record provenance, cultural narratives and usage boundaries alongside technical metadata
+- Plan for redaction or data synthesis where sharing could expose tapu knowledge
+
+---
+
+## Tiered access strategies
+- Create membership-based portals with whānau-first access and layered researcher permissions
+- Use data sharing agreements that require reciprocity, cultural briefings and return of insights
+- Establish community review boards that can veto or amend release plans
+- Schedule sunset reviews so sharing levels evolve with community comfort
+
+---
+
+## Governance & agreements
+- Memoranda of understanding outlining kaitiaki roles, dispute resolution and benefit-sharing
+- Embed cultural licences or Traditional Knowledge labels that travel with the dataset
+- Require institutional partners to appoint liaison staff accountable to tribal councils
+- Document escalation paths when requests breach protocol or legal boundaries
+
+---
+
+## Technical safeguards
+- Implement attribute-based access control and audit trails for who downloads what
+- Encrypt at rest and in transit, with keys held by community stewards
+- Use watermarking or data usage dashboards to surface secondary sharing attempts
+- Automate alerts when access patterns deviate from approved research plans
+
+---
+
+## Roles & team dynamics
+- Roles: community tech-leads, Indigenous knowledge holders, data stewards, legal counsel, platform engineers
+- Typical ratios: 1 cultural advisor per squad, 1 steward per 3–5 data partnerships
+- Entry pathways: interns from iwi digital hubs, policy analysts, data analysts retrained in cultural frameworks
+- Traits: relational, patient negotiators who can translate tikanga into platform features
+- Progression: cultural data analyst → community tech-lead → Chief Data Steward guiding cross-organisation practice
+
+---
+
+## Scenario: open dataset request
+- A university requests language audio for an open NLP corpus
+- Community council requires a CARE-aligned impact statement and co-design workshop
+- Access granted through time-bound licence, with obligations to fund digitisation and report back in te reo Māori
+- Breaches trigger suspension, restorative hui and potential withdrawal of derived models
+
+---
+
+## Key takeaway
+Openness can honour Indigenous sovereignty when cultural governance sets the terms of sharing.
+
+---


### PR DESCRIPTION
## Summary
- add slides covering how to balance openness with cultural safety and responsible data sharing in Part 7
- provide supporting speaker narratives for each major theme and scenario
- mark the Part 7 cultural safety content to-do item complete

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d661fe94ec832593440f2159bd8182