### PR TITLE
Add community tech-lead role content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -112,7 +112,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Community governance structures from single maintainer to foundations
   - [x] Draft slides and narrative: Maori case study highlighting Indigenous data sovereignty in action
   - [x] Draft slides and narrative: Balancing openness with cultural safety and responsible data sharing
-  - [ ] Draft slides and narrative: The “community tech-lead” role and career pathways in open-source projects
+  - [x] Draft slides and narrative: The “community tech-lead” role and career pathways in open-source projects
 - [ ] Create quiz questions
 
 #### Part 8 – Project Studio and Presentations

--- a/content/part-07/community-tech-lead-role/narratives/01-intro-why-role.md
+++ b/content/part-07/community-tech-lead-role/narratives/01-intro-why-role.md
@@ -1,0 +1,3 @@
+Speaker 1: Our opener frames community tech-leads as connective tissue because they sit between governance, engineering and contributor care. Once a project grows past a couple dozen maintainers, somebody has to watch the whole ecosystem.
+
+Speaker 2: Right, otherwise RFCs stall, moderation escalations slip, and users lose trust. That ratio call-out—one tech-lead per 150 to 250 active contributors—gives learners a benchmark for when to lobby their foundation for funding the role.

--- a/content/part-07/community-tech-lead-role/narratives/02-core-responsibilities.md
+++ b/content/part-07/community-tech-lead-role/narratives/02-core-responsibilities.md
@@ -1,0 +1,3 @@
+Speaker 1: On the responsibilities slide we emphasise facilitation as much as technical leadership. Tech-leads host backlog triage, shepherd RFCs and ensure incident responses loop back into documentation.
+
+Speaker 2: And they are the culture keepers. Calling out inclusive communication, mentorship pipelines and reporting to sponsors signals that this role is accountable to people, not just code.

--- a/content/part-07/community-tech-lead-role/narratives/03-bridge-workflow.md
+++ b/content/part-07/community-tech-lead-role/narratives/03-bridge-workflow.md
@@ -1,0 +1,3 @@
+Speaker 1: The bridge slide paints the tech-lead as translator—turning localisation, Indigenous data sovereignty requirements and user research into engineering tickets.
+
+Speaker 2: Exactly, and the workflow slide anchors that translation in a daily cadence. Learners see how office hours, merge queue triage and mentoring rosters all live on the same calendar.

--- a/content/part-07/community-tech-lead-role/narratives/04-entry-pathways.md
+++ b/content/part-07/community-tech-lead-role/narratives/04-entry-pathways.md
@@ -1,0 +1,3 @@
+Speaker 1: For pathways we wanted to show this isn’t a mysterious promotion—you can come through long-term contribution, fellowship programs or corporate OSPO rotations.
+
+Speaker 2: Including iwi digital innovation hubs reinforces that Indigenous technologists belong in these roles. The 4 to 6 year experience band sets expectations for skill depth without gatekeeping specific degrees.

--- a/content/part-07/community-tech-lead-role/narratives/05-skills-traits.md
+++ b/content/part-07/community-tech-lead-role/narratives/05-skills-traits.md
@@ -1,0 +1,3 @@
+Speaker 1: The skills slide leans into empathy, multilingual communication and systems thinking because tech-leads spend most of their time orchestrating people, not just writing code.
+
+Speaker 2: We also highlight calm incident facilitation and documentation-first habits—those are the traits that reduce burnout and make governance transparent to new contributors.

--- a/content/part-07/community-tech-lead-role/narratives/06-team-structure.md
+++ b/content/part-07/community-tech-lead-role/narratives/06-team-structure.md
@@ -1,0 +1,3 @@
+Speaker 1: The team slide shows how tech-leads partner with community managers, legal counsel and accessibility experts. It grounds the abstract role in a concrete staffing model.
+
+Speaker 2: Calling out stipend advocacy and data-sharing up to boards also keeps the justice lens present—tech-leads are accountable for equitable recognition, not just sprint velocity.

--- a/content/part-07/community-tech-lead-role/narratives/07-career-progression.md
+++ b/content/part-07/community-tech-lead-role/narratives/07-career-progression.md
@@ -1,0 +1,3 @@
+Speaker 1: For progression we mapped a lattice: maintainer to tech-lead to ecosystem leadership, with lateral moves into OSPOs, developer relations or policy work.
+
+Speaker 2: That helps students see longevity—this isn’t a cul-de-sac role. It can lead to foundation CTO seats or Indigenous data sovereignty leadership, which signals strategic impact.

--- a/content/part-07/community-tech-lead-role/narratives/08-key-takeaway.md
+++ b/content/part-07/community-tech-lead-role/narratives/08-key-takeaway.md
@@ -1,0 +1,3 @@
+Speaker 1: We close by reminding learners that investing in tech-leads is about sustaining trust and resilience, not just adding another title.
+
+Speaker 2: Exactly—funding this role protects values, speeds reviews and keeps governance tethered to community reality. That’s the north star for Part 7.

--- a/content/part-07/community-tech-lead-role/slides.md
+++ b/content/part-07/community-tech-lead-role/slides.md
@@ -1,0 +1,86 @@
+---
+marp: true
+title: The Community Tech-Lead Role and Career Pathways
+---
+
+# Community Tech-Leads
+*The connective tissue between code, culture and contributors*
+
+---
+
+## Why the role exists
+- Mature projects need a bridge between maintainers, contributors and users
+- Tech-leads translate community values into technical direction and roadmap trade-offs
+- They coordinate security, accessibility and localisation work that no single maintainer can own
+- Rough ratio: 1 tech-lead per 150–250 active contributors to keep reviews under 72 hours
+- Without them, governance charters drift from reality and contributor trust erodes
+
+---
+
+## Core responsibilities
+- Facilitate backlog triage, RFC discussions and release planning with transparent decision logs
+- Model inclusive communication and uphold the code of conduct in technical forums
+- Pair emerging maintainers with mentors and steward succession plans for critical subsystems
+- Own dependency hygiene, SBOM updates and incident coordination across distributed teams
+- Report progress to fiscal sponsors, foundations and partner organisations
+
+---
+
+## Bridging community & engineering
+- Hosts contributor office hours across time zones and languages
+- Converts user research, localisation feedback and Indigenous data protocols into actionable issues
+- Maintains tooling for translation, documentation builds and contributor analytics
+- Negotiates with corporate stakeholders to ensure funding aligns with community roadmap
+- Acts as escalation path for moderation teams when disputes have technical roots
+
+---
+
+## Day-to-day workflow
+- Morning: async stand-up posts, merge queue review, security patch triage
+- Midday: roadmap sync with governance committee, unblock volunteer maintainers, update mentoring roster
+- Evening: community livestream or timezone-friendly pairing session
+- Time allocation trends: ~35% technical design, 30% community facilitation, 20% mentoring, 15% reporting
+- Success metric: 90% of pull requests receive actionable feedback within three business days
+
+---
+
+## Entry pathways
+- Long-term contributor promoted after stewarding a module through multiple releases
+- Fellows from programs like Outreachy, Google Season of Docs or GitHub OSS Maintainer Scholarships
+- Engineers rotating out of corporate OSPOs seeking community-facing leadership
+- Community organisers with technical upskilling via bootcamps or iwi digital innovation hubs
+- Typical baseline: 4–6 years combined engineering and facilitation experience with demonstrated community impact
+
+---
+
+## Skills & traits that stick
+- Bilingual or multilingual communication to bridge global communities
+- High empathy and conflict navigation, grounded in cultural safety principles
+- Systems thinking to map how infrastructure, funding and governance intersect
+- Calm under incident pressure; able to host blameless retros that include community voice
+- Documentation-first mindset so decisions are legible to newcomers
+
+---
+
+## Working with the wider team
+- Partners closely with product/community managers, legal counsel and accessibility reviewers
+- Oversees volunteer squads: docs, localisation, security response, release engineering
+- Advocates for stipend budgets and equitable recognition programs
+- Ensures foundation boards hear frontline contributor data before policy votes
+- Typical staffing: 1 community tech-lead supported by 2–3 senior maintainers and 4–6 rotating fellows
+
+---
+
+## Career progression
+- Entry: Maintainer or module steward coordinating limited scope features
+- Mid-level: Community tech-lead accountable for cross-project initiatives and contributor health metrics
+- Senior: Ecosystem lead or OSPO director guiding multi-project strategy and funding partnerships
+- Executive pathways: Foundation CTO, cooperative digital steward, or policy advisor on open-source sustainability
+- Career lattice allows lateral moves into developer relations, governance, or Indigenous data sovereignty leadership roles
+
+---
+
+## Key takeaway
+Intentional investment in community tech-leads sustains contributor trust, equitable governance and long-term project resilience.
+
+---


### PR DESCRIPTION
## Summary
- add slides detailing responsibilities, workflows, and progression for community tech-leads in part 7
- provide narrative scripts emphasising pathways, traits, and team structures for the role
- mark the community tech-lead content task complete in the overall to-do list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d76226d7dc83258b2f94924f4a6fee