### PR TITLE
Add Revoicer apt repository to environment setup

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Add Revoicer package repository
+echo "deb [trusted=yes] https://packages.industrial-linguistics.com/revoicer/debian stable main" | sudo tee /etc/apt/sources.list.d/revoicer.list >/dev/null
+
 # Install base tools
 sudo apt-get update
 sudo apt-get install -y nodejs npm ffmpeg golang-go jq


### PR DESCRIPTION
## Summary
- add the Industrial Linguistics Revoicer repository to the setup script so apt can install the package
- preserve existing installation steps for base tools and Marp CLI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d86cf758f48325be32093177baf848