### PR TITLE
Install revoicer package in environment setup script

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -6,7 +6,7 @@ echo "deb [trusted=yes] https://packages.industrial-linguistics.com/revoicer/deb
 
 # Install base tools
 sudo apt-get update
-sudo apt-get install -y nodejs npm ffmpeg golang-go jq
+sudo apt-get install -y nodejs npm ffmpeg golang-go jq revoicer
 
 # Install Marp CLI for slide rendering
 sudo npm install -g @marp-team/marp-cli


### PR DESCRIPTION
## Summary
- add the revoicer package to the base apt-get install list in envsetup.sh to ensure it is available after setup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d872af3e60832597658f9981a1b968