### PR TITLE
Move part 6 TODO placeholders into TODO list

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -103,6 +103,29 @@ Use the checklist below to track progress for each part.
 #### Part 6 – Start-ups & Small-Biz IT
 - [x] Outline objectives and key topics
 - [x] Create to-do list items for each topic to draft slides and write narratives
+  - [ ] Draft slides and narrative: Business continuity planning essentials for small teams, including the MongoDB outage anecdote
+  - [ ] Draft slides and narrative: Capstone red team group exercise structure and maturity model mapping activity
+  - [ ] Draft slides and narrative: Capstone remediation roadmap with take-home planning and reflection prompts
+  - [ ] Draft slides and narrative: Cloud versus on-premise decisions, including free tier comparisons and container adoption timing
+  - [ ] Draft slides and narrative: Day zero assessment checklist covering identity, endpoint, backup and security controls
+  - [ ] Draft slides and narrative: Day zero core services setup—from incorporation and domains to devices—with Sarah's DNS cautionary tale
+  - [ ] Draft slides and narrative: Fractional CTO and MSP partnership models with evaluation questions
+  - [ ] Draft slides and narrative: Guest speaker ideas and the perspectives they bring to the session
+  - [ ] Draft slides and narrative: Investor due diligence preparation, red flags and policy-to-board mapping tips
+  - [ ] Draft slides and narrative: Legal compliance reality check across milestones, open source duties and privacy-by-design
+  - [ ] Draft slides and narrative: Lightweight SaaS selection trade-offs and the Zoom-to-Teams migration case study
+  - [ ] Draft slides and narrative: Mock vendor evaluation role-play structure and discussion prompts
+  - [ ] Draft slides and narrative: Pre-seed tool stack, monthly costs and decision cues for staying lean
+  - [ ] Draft slides and narrative: Regional compliance considerations and global data governance expectations
+  - [ ] Draft slides and narrative: Remote-first reality check for onboarding, device logistics and distributed contractors
+  - [ ] Draft slides and narrative: Remote talent logistics at scale—from hardware standards to automated access reviews
+  - [ ] Draft slides and narrative: Scaling support processes, help desks, knowledge bases and ITSM tooling choices
+  - [ ] Draft slides and narrative: Security baselines on a shoestring, including outsourced SOC and lightweight monitoring defaults
+  - [ ] Draft slides and narrative: Series A tool stack, costs and serverless versus container trade-offs
+  - [ ] Draft slides and narrative: Series B enterprise stack, integrations and cost modelling worksheet
+  - [ ] Draft slides and narrative: Shadow IT and low-code experimentation with guardrails against over-permissioning
+  - [ ] Draft slides and narrative: Start-up budgeting and FinOps with cloud credit optimisation talking points
+  - [ ] Draft slides and narrative: Vendor management rhythms, cadence rituals, scorecards and make-vs-buy considerations
 - [x] Create quiz questions
 
 #### Part 7 – Open-Source & Indigenous Digital Sovereignty

--- a/content/part-06/business-continuity-small-teams/slides.md
+++ b/content/part-06/business-continuity-small-teams/slides.md
@@ -4,7 +4,5 @@ title: Business Continuity for Small Teams
 ---
 
 # Business Continuity for Small Teams
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Cover continuity planning essentials with the MongoDB outage anecdote. -->

--- a/content/part-06/capstone-red-team-exercise/slides.md
+++ b/content/part-06/capstone-red-team-exercise/slides.md
@@ -4,7 +4,5 @@ title: Capstone: Red Team Your Friend's Startup
 ---
 
 # Capstone: Red Team Your Friend's Startup
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Lay out the capstone group exercise structure and maturity model mapping activity. -->

--- a/content/part-06/capstone-remediation-roadmap/slides.md
+++ b/content/part-06/capstone-remediation-roadmap/slides.md
@@ -4,7 +4,5 @@ title: Capstone: Remediation Roadmap
 ---
 
 # Capstone: Remediation Roadmap
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Plan the take-home remediation roadmap and reflection prompts for the capstone. -->

--- a/content/part-06/cloud-vs-on-premise-decisions/slides.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/slides.md
@@ -4,7 +4,5 @@ title: Cloud vs On-Premise Decisions
 ---
 
 # Cloud vs On-Premise Decisions
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Evaluate free tiers across major cloud providers and when to adopt containers versus staying serverless. -->

--- a/content/part-06/day-zero-assessment-checklist/slides.md
+++ b/content/part-06/day-zero-assessment-checklist/slides.md
@@ -4,7 +4,5 @@ title: Day-Zero Startup IT Assessment
 ---
 
 # Day-Zero Startup IT Assessment
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Draft the identity, endpoint, backup and security checklist used on day zero. -->

--- a/content/part-06/day-zero-core-services/slides.md
+++ b/content/part-06/day-zero-core-services/slides.md
@@ -4,7 +4,5 @@ title: Day-Zero Core Services Setup
 ---
 
 # Day-Zero Core Services Setup
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Outline company incorporation steps, domain registration, productivity suite choices and device procurement basics, including Sarah's DNS cautionary tale. -->

--- a/content/part-06/fractional-cto-and-msps/slides.md
+++ b/content/part-06/fractional-cto-and-msps/slides.md
@@ -4,7 +4,5 @@ title: Working with Fractional CTOs and MSPs
 ---
 
 # Working with Fractional CTOs and MSPs
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Explain partnership models with fractional leaders and MSPs, including evaluation questions. -->

--- a/content/part-06/guest-speaker-ideas/slides.md
+++ b/content/part-06/guest-speaker-ideas/slides.md
@@ -4,7 +4,5 @@ title: Guest Speaker Ideas
 ---
 
 # Guest Speaker Ideas
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: List potential guest experts and the perspectives they bring to the session. -->

--- a/content/part-06/investor-due-diligence-prep/slides.md
+++ b/content/part-06/investor-due-diligence-prep/slides.md
@@ -4,7 +4,5 @@ title: Preparing for Investor Due Diligence
 ---
 
 # Preparing for Investor Due Diligence
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Describe diligence artifacts, common red flags and policy-to-board mapping tips. -->

--- a/content/part-06/legal-compliance-reality-check/slides.md
+++ b/content/part-06/legal-compliance-reality-check/slides.md
@@ -4,7 +4,5 @@ title: Legal and Compliance Reality Check
 ---
 
 # Legal and Compliance Reality Check
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Outline compliance milestones, open source obligations and privacy-by-design guidance. -->

--- a/content/part-06/lightweight-saas-selection/slides.md
+++ b/content/part-06/lightweight-saas-selection/slides.md
@@ -4,7 +4,5 @@ title: Selecting Lightweight SaaS Platforms
 ---
 
 # Selecting Lightweight SaaS Platforms
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Cover SaaS selection trade-offs and the Zoom-to-Teams migration case study. -->

--- a/content/part-06/mock-vendor-evaluation-exercise/slides.md
+++ b/content/part-06/mock-vendor-evaluation-exercise/slides.md
@@ -4,7 +4,5 @@ title: Mock Vendor Evaluation Exercise
 ---
 
 # Mock Vendor Evaluation Exercise
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Outline the vendor evaluation role-play structure and discussion prompts. -->

--- a/content/part-06/pre-seed-tool-stack/slides.md
+++ b/content/part-06/pre-seed-tool-stack/slides.md
@@ -4,7 +4,5 @@ title: Pre-Seed Tool Stack Example
 ---
 
 # Pre-Seed Tool Stack Example
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Detail the sample pre-seed stack, monthly costs and decision cues for staying lean. -->

--- a/content/part-06/regional-compliance-considerations/slides.md
+++ b/content/part-06/regional-compliance-considerations/slides.md
@@ -4,7 +4,5 @@ title: Regional Compliance Considerations
 ---
 
 # Regional Compliance Considerations
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Summarise global compliance pressures and data governance expectations. -->

--- a/content/part-06/remote-first-reality-check/slides.md
+++ b/content/part-06/remote-first-reality-check/slides.md
@@ -4,7 +4,5 @@ title: Remote-First Reality Check
 ---
 
 # Remote-First Reality Check
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Cover remote onboarding, device logistics and managing a distributed contractor workforce. -->

--- a/content/part-06/remote-talent-logistics-scale/slides.md
+++ b/content/part-06/remote-talent-logistics-scale/slides.md
@@ -4,7 +4,5 @@ title: Remote Talent Logistics at Scale
 ---
 
 # Remote Talent Logistics at Scale
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Describe scaling remote logistics, from hardware standards to automated access reviews. -->

--- a/content/part-06/scaling-support-processes/slides.md
+++ b/content/part-06/scaling-support-processes/slides.md
@@ -4,7 +4,5 @@ title: Scaling Support Processes
 ---
 
 # Scaling Support Processes
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Plan guidance on evolving help desks, knowledge bases and ITSM tooling choices. -->

--- a/content/part-06/security-baselines-shoestring/slides.md
+++ b/content/part-06/security-baselines-shoestring/slides.md
@@ -4,7 +4,5 @@ title: Security Baselines on a Shoestring
 ---
 
 # Security Baselines on a Shoestring
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Summarise affordable security controls, outsourced SOC options and lightweight monitoring defaults. -->

--- a/content/part-06/series-a-tool-stack/slides.md
+++ b/content/part-06/series-a-tool-stack/slides.md
@@ -4,7 +4,5 @@ title: Series A Tool Stack Example
 ---
 
 # Series A Tool Stack Example
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Summarise the Series A tooling mix, costs and serverless versus container considerations. -->

--- a/content/part-06/series-b-enterprise-stack/slides.md
+++ b/content/part-06/series-b-enterprise-stack/slides.md
@@ -4,7 +4,5 @@ title: Series B Enterprise Stack
 ---
 
 # Series B Enterprise Stack
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Explain the Series B enterprise tooling mix, integrations and cost modelling worksheet. -->

--- a/content/part-06/shadow-it-low-code-experimentation/slides.md
+++ b/content/part-06/shadow-it-low-code-experimentation/slides.md
@@ -4,7 +4,5 @@ title: Shadow IT and Low-Code Experimentation
 ---
 
 # Shadow IT and Low-Code Experimentation
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Discuss empowering teams with no-code while avoiding chaos and accidental over-permissioning. -->

--- a/content/part-06/startup-budgeting-finops/slides.md
+++ b/content/part-06/startup-budgeting-finops/slides.md
@@ -4,7 +4,5 @@ title: Budgeting and FinOps for Start-ups
 ---
 
 # Budgeting and FinOps for Start-ups
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Plan the FinOps budgeting activity and cloud credit optimisation talking points. -->

--- a/content/part-06/vendor-management-rhythms/slides.md
+++ b/content/part-06/vendor-management-rhythms/slides.md
@@ -4,7 +4,5 @@ title: Vendor Management Rhythms
 ---
 
 # Vendor Management Rhythms
-*TODO: Draft slide headlines and visuals.*
 
 ---
-<!-- TODO: Detail cadence rituals, scorecards and make-vs-buy considerations for vendors. -->


### PR DESCRIPTION
## Summary
- remove inline TODO placeholders from the part 6 slide decks
- add outstanding part 6 drafting work to the central TODO list with detailed checkboxes

## Testing
- not run (content-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d92f9aadb48325bf1c11eca6bd2dec