### PR TITLE
Add capstone red team exercise content for Part 6

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,7 +104,7 @@ Use the checklist below to track progress for each part.
 - [x] Outline objectives and key topics
 - [x] Create to-do list items for each topic to draft slides and write narratives
   - [x] Draft slides and narrative: Business continuity planning essentials for small teams, including the MongoDB outage anecdote
-  - [ ] Draft slides and narrative: Capstone red team group exercise structure and maturity model mapping activity
+  - [x] Draft slides and narrative: Capstone red team group exercise structure and maturity model mapping activity
   - [ ] Draft slides and narrative: Capstone remediation roadmap with take-home planning and reflection prompts
   - [ ] Draft slides and narrative: Cloud versus on-premise decisions, including free tier comparisons and container adoption timing
   - [ ] Draft slides and narrative: Day zero assessment checklist covering identity, endpoint, backup and security controls

--- a/content/part-06/capstone-red-team-exercise/narratives/01.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/01.md
@@ -1,0 +1,4 @@
+Speaker 1: [energized] This capstone is your chance to break things safely. We pressure-test a 15-person startup without touching their production stack.
+Speaker 2: The goal is to practice red-team curiosity, blue-team calm and facilitation skills that keep stakeholders engaged instead of defensive.
+Speaker 1: We finish by translating every insight into a maturity score and a backlog leaders can actually fund.
+Speaker 2: And along the way we highlight the cross-functional cast—fractional CTOs, success managers, ops leads—who make improvements stick.

--- a/content/part-06/capstone-red-team-exercise/narratives/02.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/02.md
@@ -1,0 +1,4 @@
+Speaker 1: Our scenario centers on Sarah's marketplace startup—fifteen people juggling weekly releases, contractors and a global customer base.
+Speaker 2: Their stack is modern but stitched together: managed Kubernetes, GitHub Actions, Google Workspace, Notion, HubSpot, Stripe.
+Speaker 1: They lean on a fractional SOC, an MSP for laptops and an offshore labeling partner, so third-party trust boundaries really matter.
+Speaker 2: Pain points are already on the table: ad-hoc onboarding, shadow SaaS creep, almost no incident rehearsal and compliance debt chasing them into every sales call.

--- a/content/part-06/capstone-red-team-exercise/narratives/03.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/03.md
@@ -1,0 +1,4 @@
+Speaker 1: We split into pods of five or six—red-team analysts, blue-team responders, a business voice and a scribe.
+Speaker 2: Ninety minutes goes fast, so the facilitator guards the timeboxes: twenty for recon, thirty for the live drill, twenty-five to debrief, fifteen to prep the share-out.
+Speaker 1: Injects keep everyone honest, but the tone stays curious, not accusatory.
+Speaker 2: Everything you need lives in the shared workspace—architecture map, SaaS inventory, contract snippets, customer personas—so no one is guessing.

--- a/content/part-06/capstone-red-team-exercise/narratives/04.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/04.md
@@ -1,0 +1,4 @@
+Speaker 1: Phase one is pure recon. The red team maps assets, data flows and every third-party touchpoint they can spot.
+Speaker 2: We ask for the top three attack vectors—with evidence. Credential reuse? Misconfigured S3 buckets? Vendor breach cascading into production?
+Speaker 1: Each threat must tie back to business impact so sales, support and engineering leaders understand the stakes.
+Speaker 2: The scribe logs unanswered questions to keep momentum while still capturing gaps for later homework.

--- a/content/part-06/capstone-red-team-exercise/narratives/05.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/05.md
@@ -1,0 +1,4 @@
+Speaker 1: In phase two, the facilitator picks a scenario—maybe a compromised GitHub token that poisons container images.
+Speaker 2: Blue-team responders narrate how they'd spot it, contain it, communicate with customers and loop in legal or finance.
+Speaker 1: Injects keep tension high: a product launch collides with the incident, the MSP contact is offline, the SOC queue is overflowing.
+Speaker 2: We encourage teams to draft customer updates, board brief talking points and even postmortem outlines while the adrenaline is still flowing.

--- a/content/part-06/capstone-red-team-exercise/narratives/06.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/06.md
@@ -1,0 +1,4 @@
+Speaker 1: Debrief time means switching to evidence-based grading. Each pod scores people, process, technology and governance on a one-to-five scale.
+Speaker 2: We tie every score to artifacts—outdated runbooks, missing tabletop cadence, a single approver on critical releases.
+Speaker 1: Then we prioritize the backlog: lightning fixes like closing MFA gaps, medium-term plays like renegotiating vendor contracts, strategic bets like observability upgrades.
+Speaker 2: Finally, we capture what leadership must unlock—budget, headcount, or policy—to sustain momentum.

--- a/content/part-06/capstone-red-team-exercise/narratives/07.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/07.md
@@ -1,0 +1,4 @@
+Speaker 1: The maturity model keeps scoring consistent. Level one is ad hoc—heroics, no playbooks, barely any logging.
+Speaker 2: Level two is emerging: some runbooks, partial MFA, retros that happen but rarely translate into change.
+Speaker 1: Level three is scaling—quarterly tabletops, defined SLAs, vendor scorecards, baseline observability.
+Speaker 2: Level four is measured with automated controls, resilience OKRs and real budgets; level five is optimized, where purple teaming and partner collaboration are business as usual.

--- a/content/part-06/capstone-red-team-exercise/narratives/08.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/08.md
@@ -1,0 +1,4 @@
+Speaker 1: Each pod leaves with tangible artifacts: a risk map, attack narrative, maturity scores and a remediation backlog with owners and timelines.
+Speaker 2: Visuals help—journey maps, swimlanes, heat maps make executive conversations concrete rather than theoretical.
+Speaker 1: We use a "start, stop, continue" debrief to surface cultural shifts alongside technical fixes.
+Speaker 2: And everyone closes with a commitment statement so momentum carries beyond the classroom.

--- a/content/part-06/capstone-red-team-exercise/narratives/09.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/09.md
@@ -1,0 +1,4 @@
+Speaker 1: The exercise spotlights multiple roles: fractional CTOs, security leads, product managers, customer success managers, operations analysts.
+Speaker 2: Entry points vary—support engineers stepping into incident command, consultants shifting into virtual CISO work, operations generalists owning vendor programs.
+Speaker 1: The standout traits are facilitation under pressure, systems thinking, empathy for non-technical teammates and curiosity about adversary tradecraft.
+Speaker 2: Nail this capstone and you're charting a path toward security program management, resilience leadership or platform engineering direction.

--- a/content/part-06/capstone-red-team-exercise/narratives/10.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/10.md
@@ -1,0 +1,4 @@
+Speaker 1: The takeaway is simple: rehearsal builds muscle memory faster than policy memos ever could.
+Speaker 2: By red-teaming Sarah's startup together, we generate evidence-backed maturity scores and a sequenced roadmap that leaders can champion.
+Speaker 1: Treat the session like prep for the next diligence meeting—you want answers ready before investors or auditors ask.
+Speaker 2: And the real win is renewed shared accountability before the inevitable real-world incident arrives.

--- a/content/part-06/capstone-red-team-exercise/narratives/outline.md
+++ b/content/part-06/capstone-red-team-exercise/narratives/outline.md
@@ -1,9 +1,9 @@
 # Narrative Outline — Capstone: Red Team Your Friend's Startup
 
 ## Tasks
-- [ ] Design the group exercise to critique a sample startup toolchain.
-- [ ] Include steps for running a security incident drill for a 15-person team.
-- [ ] Show how to map Sarah's company onto the maturity model as part of the debrief.
+- [x] Design the group exercise to critique a sample startup toolchain.
+- [x] Include steps for running a security incident drill for a 15-person team.
+- [x] Show how to map Sarah's company onto the maturity model as part of the debrief.
 
 ## Notes
-- Lay out the capstone group exercise structure and maturity model mapping activity.
+- Lay out the capstone group exercise structure and maturity model mapping activity with concrete timelines, roles and deliverables.

--- a/content/part-06/capstone-red-team-exercise/slides.md
+++ b/content/part-06/capstone-red-team-exercise/slides.md
@@ -4,5 +4,86 @@ title: Capstone: Red Team Your Friend's Startup
 ---
 
 # Capstone: Red Team Your Friend's Startup
+*Group exercise structure and maturity mapping*
+
+---
+
+## Capstone objectives
+- Stress-test a 15-person startup's toolchain, culture and vendor choices without breaking production.
+- Practice red-team thinking, blue-team response and facilitation skills in a psychologically safe setting.
+- Map findings to an actionable maturity model so leaders leave with a prioritized remediation backlog.
+- Showcase cross-functional roles—from fractional CTO to customer success—needed to sustain improvements.
+
+---
+
+## Scenario setup
+- Sarah's marketplace startup: 15 staff, a mix of contractors and founders shipping weekly product updates.
+- Stack: managed Kubernetes cluster, GitHub Actions CI/CD, Google Workspace, Notion, HubSpot and Stripe.
+- Third parties: fractional SOC provider, MSP handling endpoints, offshore data labeling partner.
+- Known pain points: ad-hoc onboarding, shadow SaaS, limited incident rehearsal and compliance debt.
+
+---
+
+## Team structure & logistics
+- Participants form pods of 5–6: red-team analysts, blue-team responders, a business stakeholder and a scribe.
+- 90-minute block: 20-minute recon, 30-minute incident drill, 25-minute debrief, 15-minute report-out prep.
+- Facilitator provides injects, timeboxes discussions and keeps the tone curious rather than accusatory.
+- Shared workspace includes architecture diagram, SaaS inventory, contract excerpts and customer personas.
+
+---
+
+## Phase 1 — Recon & hypothesis building
+- Red team maps the startup's assets, data flows, trust boundaries and third-party dependencies.
+- Identify top three attack vectors (credential reuse, misconfigured S3, vendor breach) with supporting evidence.
+- Draft "assume breach" scenarios that articulate the business impact for sales, support and engineering leaders.
+- Scribe captures questions for the facilitator to answer or park for later research.
+
+---
+
+## Phase 2 — Simulated incident drill
+- Facilitator triggers a chosen scenario: e.g., compromised GitHub token leading to tampered container images.
+- Blue team walks through detection sources, containment steps, communication cadences and legal escalations.
+- Injects add twists: incident overlaps with product launch, MSP lead is on leave, or SOC ticket queue is full.
+- Encourage practicing customer updates, board briefs and postmortem draft outlines in real time.
+
+---
+
+## Phase 3 — Debrief & maturity mapping
+- Teams grade the startup across people, process, technology and governance dimensions using 1–5 scale.
+- Tie observations to evidence: outdated runbooks, missing tabletop cadence, single approver for releases.
+- Prioritize remediation backlog: quick wins (MFA gaps), medium-term (vendor contract reviews), strategic plays (platform observability).
+- Capture leadership asks: budget, headcount or policy changes needed to support improvements.
+
+---
+
+## Maturity model cheat sheet
+- **Level 1 — Ad hoc:** hero-driven fixes, no defined playbooks, limited logging or third-party oversight.
+- **Level 2 — Emerging:** basic runbooks, partial MFA rollout, informal retros but inconsistent follow-through.
+- **Level 3 — Scaling:** quarterly tabletop drills, defined SLAs, vendor scorecards, baseline observability.
+- **Level 4 — Measured:** automated controls, resilience OKRs, integrated risk dashboards, dedicated budget.
+- **Level 5 — Optimized:** continuous assurance, proactive purple teaming, shared outcomes with partners.
+
+---
+
+## Deliverables & facilitation cues
+- Pod outputs: risk map, attack narrative, maturity scores, top-five remediation backlog with owners and timelines.
+- Encourage visual artifacts—journey maps, swimlanes, heat maps—to anchor executive conversations.
+- Debrief using "start, stop, continue" format to surface culture shifts alongside technical fixes.
+- Close with commitment round: each role states the next concrete action they will champion post-session.
+
+---
+
+## Roles, traits & progression
+- Roles represented: fractional CTO, security lead, product manager, customer success manager, operations analyst.
+- Entry pathways include support engineers stepping into incident command, consultants pivoting into vCISO roles and ops generalists leading vendor management.
+- Standout traits: facilitation under pressure, systems thinking, empathy for non-technical stakeholders and curiosity about adversary tradecraft.
+- Career progression: red-team exercise leads can grow into security program managers, heads of resilience or platform engineering directors.
+
+---
+
+## Key takeaway
+A well-structured capstone turns abstract resilience talk into muscle memory.
+By stress-testing Sarah's startup collaboratively, teams leave with evidence-backed maturity scores, a sequenced roadmap and renewed respect for cross-functional partnership.
+Treat the exercise as a rehearsal for the next funding round diligence meeting—and an invitation to invest in shared accountability before the real incident hits.
 
 ---


### PR DESCRIPTION
## Summary
- expand the capstone red team exercise slide deck with objectives, scenario details, facilitation flow, maturity rubric and key takeaway
- add narrated scripts for each slide covering recon, incident injects, debrief expectations and career context
- mark the Part 6 capstone exercise to-do item complete and update the narrative outline tasks accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9cda1d8bc8325ac533ef25036b6c8