### PR TITLE
Add materials for cloud vs on-premise decisions lesson

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,7 +106,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Business continuity planning essentials for small teams, including the MongoDB outage anecdote
   - [x] Draft slides and narrative: Capstone red team group exercise structure and maturity model mapping activity
   - [x] Draft slides and narrative: Capstone remediation roadmap with take-home planning and reflection prompts
-  - [ ] Draft slides and narrative: Cloud versus on-premise decisions, including free tier comparisons and container adoption timing
+  - [x] Draft slides and narrative: Cloud versus on-premise decisions, including free tier comparisons and container adoption timing
   - [ ] Draft slides and narrative: Day zero assessment checklist covering identity, endpoint, backup and security controls
   - [ ] Draft slides and narrative: Day zero core services setup—from incorporation and domains to devices—with Sarah's DNS cautionary tale
   - [ ] Draft slides and narrative: Fractional CTO and MSP partnership models with evaluation questions

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/01.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/01.md
@@ -1,3 +1,3 @@
 Speaker 1: When founders say "we need to pick cloud or on-prem," they're really deciding where compute, storage, networking and identity will live.
-Speaker 2: Exactly—and the answer can be different for each layer. You might keep authentication in SaaS, run workloads on managed Kubernetes and colocate a latency-sensitive appliance.
-Speaker 1: The smart move is to map what customers expect, what regulators demand and what your team can realistically operate.
+Speaker 2: Exactly—and the answer can differ per layer. SaaS keeps you hands-off, PaaS gives you guardrails, and IaaS is the build-it-yourself toolbox.
+Speaker 1: Add in acronyms like SRE and questions about colocation versus true on-prem, and it's easy to lose clarity. Start by mapping what customers expect, what regulators demand and what your team can realistically operate.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/01.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/01.md
@@ -1,0 +1,3 @@
+Speaker 1: When founders say "we need to pick cloud or on-prem," they're really deciding where compute, storage, networking and identity will live.
+Speaker 2: Exactly—and the answer can be different for each layer. You might keep authentication in SaaS, run workloads on managed Kubernetes and colocate a latency-sensitive appliance.
+Speaker 1: The smart move is to map what customers expect, what regulators demand and what your team can realistically operate.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/02.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/02.md
@@ -1,0 +1,3 @@
+Speaker 1: In the first twelve months, speed beats everything—use the managed services that let you ship without hiring SREs.
+Speaker 2: By year two, finance wants predictability. That's when you compare reserved cloud instances to colocated gear and understand your utilisation curves.
+Speaker 1: As you approach Series B, you revisit the architecture. Maybe customer data has to stay in-region, or latency targets push you toward an edge footprint.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/02.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/02.md
@@ -1,3 +1,4 @@
 Speaker 1: In the first twelve months, speed beats everything—use the managed services that let you ship without hiring SREs.
-Speaker 2: By year two, finance wants predictability. That's when you compare reserved cloud instances to colocated gear and understand your utilisation curves.
-Speaker 1: As you approach Series B, you revisit the architecture. Maybe customer data has to stay in-region, or latency targets push you toward an edge footprint.
+Speaker 2: Right, because you literally can't afford to hire SREs yet. A senior SRE costs $180k+ in salary alone, before tooling or on-call bonuses.
+Speaker 1: By year two, finance wants predictability. That's when you compare reserved cloud instances to colocated gear and understand your utilisation curves.
+Speaker 2: And as you approach Series B, you revisit the architecture—maybe customer data has to stay in-region, or latency targets push you toward an edge footprint.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/03.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/03.md
@@ -1,3 +1,3 @@
 Speaker 1: Serverless is a gift when you're still searching for product-market fit. No patching, no capacity planning—just deploy functions.
-Speaker 2: And the bill stays tiny while usage is modest. You only pay when customers actually trigger the code.
-Speaker 1: The trade-off is vendor coupling, so schedule periodic reviews of the APIs and export your data to keep an exit option alive.
+Speaker 2: And the bill stays tiny while usage is modest. That food delivery beta with a hundred testers might cost $50 a month instead of thousands in idle servers.
+Speaker 1: The trade-off is vendor coupling, so script periodic API reviews, export datasets and rehearse migrations so an exit option stays alive.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/03.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/03.md
@@ -1,0 +1,3 @@
+Speaker 1: Serverless is a gift when you're still searching for product-market fit. No patching, no capacity planning—just deploy functions.
+Speaker 2: And the bill stays tiny while usage is modest. You only pay when customers actually trigger the code.
+Speaker 1: The trade-off is vendor coupling, so schedule periodic reviews of the APIs and export your data to keep an exit option alive.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/04.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/04.md
@@ -1,3 +1,4 @@
 Speaker 1: Managed services sit in the middle—they remove toil but still let you shape the environment.
-Speaker 2: Think managed Kubernetes, relational databases, or desktop-as-a-service. You keep control planes through infrastructure as code so the setup is reproducible.
-Speaker 1: Just remember: even if the provider handles hardware, your team still carries the pager for misconfigurations and app bugs.
+Speaker 2: That serverless approach we just mentioned? Managed platforms are the next step when you need more knobs without rebuilding plumbing.
+Speaker 1: Think managed Kubernetes, relational databases or desktop-as-a-service, all defined through infrastructure as code so the setup is reproducible.
+Speaker 2: Just remember: even if the provider handles hardware, your team still carries the pager for misconfigurations and app bugs.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/04.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/04.md
@@ -1,0 +1,3 @@
+Speaker 1: Managed services sit in the middle—they remove toil but still let you shape the environment.
+Speaker 2: Think managed Kubernetes, relational databases, or desktop-as-a-service. You keep control planes through infrastructure as code so the setup is reproducible.
+Speaker 1: Just remember: even if the provider handles hardware, your team still carries the pager for misconfigurations and app bugs.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/05.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/05.md
@@ -1,0 +1,3 @@
+Speaker 1: Containers and self-managed stacks promise cost control, but they demand engineering maturity.
+Speaker 2: You need observability, vulnerability scanning, hardened base images and a registry strategy, otherwise you simply move the risk from AWS to your office.
+Speaker 1: Factor in redundancy, hardware spares and remote hands support before declaring it cheaper than cloud.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/05.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/05.md
@@ -1,3 +1,3 @@
-Speaker 1: Containers and self-managed stacks promise cost control, but they demand engineering maturity.
-Speaker 2: You need observability, vulnerability scanning, hardened base images and a registry strategy, otherwise you simply move the risk from AWS to your office.
-Speaker 1: Factor in redundancy, hardware spares and remote hands support before declaring it cheaper than cloud.
+Speaker 1: Containers promise cost control, but they demand engineering maturity.
+Speaker 2: Without observability, vulnerability scanning, hardened base images and a registry strategy, you're just moving risk from AWS into your unfinished build pipeline.
+Speaker 1: Treat the platform like a product—budget time for upgrades, policy automation and yes, the coffee-machine moment when you realise you built something no one can maintain.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/06.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/06.md
@@ -1,3 +1,3 @@
 Speaker 1: Startup credits are powerful if you plan ahead—AWS Activate, Azure for Startups and Google Cloud can subsidise six figures of usage.
-Speaker 2: Make a burn-down chart of credits versus forecasted spend, and set alerts 90 days before expiry so finance is ready for the real bill.
-Speaker 1: Pair those credits with SaaS products that have generous free tiers so you don't waste credits on commodity tooling.
+Speaker 2: Make a burn-down chart of credits versus forecasted spend, and remember AWS Activate credits expire after two years or once you raise a Series A.
+Speaker 1: Pair those credits with SaaS products that have generous free tiers so you don't waste credits on commodity tooling—and avoid the "we thought it was still free" surprise invoice.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/06.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/06.md
@@ -1,0 +1,3 @@
+Speaker 1: Startup credits are powerful if you plan ahead—AWS Activate, Azure for Startups and Google Cloud can subsidise six figures of usage.
+Speaker 2: Make a burn-down chart of credits versus forecasted spend, and set alerts 90 days before expiry so finance is ready for the real bill.
+Speaker 1: Pair those credits with SaaS products that have generous free tiers so you don't waste credits on commodity tooling.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/07.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/07.md
@@ -1,0 +1,3 @@
+Speaker 1: Before you jump into containers, ask whether your CI/CD actually enforces testing and security scanning today.
+Speaker 2: Also, who is on the hook for 24/7 monitoring? A three-person team cannot sustain night shifts and keep product velocity high.
+Speaker 1: And double-check the legal angle—many "requirements" against managed services vanish once you read the contract clauses closely.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/07.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/07.md
@@ -1,3 +1,3 @@
 Speaker 1: Before you jump into containers, ask whether your CI/CD actually enforces testing and security scanning today.
 Speaker 2: Also, who is on the hook for 24/7 monitoring? A three-person team cannot sustain night shifts and keep product velocity high.
-Speaker 1: And double-check the legal angle—many "requirements" against managed services vanish once you read the contract clauses closely.
+Speaker 1: If your "on-call rotation" is just Sarah checking her phone during dinner, that's your answer. Then double-check the legal angle—many "requirements" against managed services vanish once you read the contract clauses closely.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/08.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/08.md
@@ -1,0 +1,3 @@
+Speaker 1: Treat architecture choices as living documents—review them at every funding milestone.
+Speaker 2: Build total cost of ownership models that include people, tooling, support plans and the opportunity cost of moving slower.
+Speaker 1: And sketch migration runbooks now. When the day comes to leave serverless or exit a co-lo, you want a rehearsed plan, not a scramble.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/09.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/09.md
@@ -1,0 +1,3 @@
+Speaker 1: When teams feel stuck, a simple decision tree clarifies the next move—speed, headcount and compliance narrow the field quickly.
+Speaker 2: If you need a prototype in minutes, stay serverless. Fewer than three engineers? Managed services keep you shipping without drowning in maintenance.
+Speaker 1: And if regulators or customers insist on strict controls, you sketch a hybrid or colocation footprint early so the surprise audits don't derail launch day.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/10.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/10.md
@@ -1,0 +1,3 @@
+Speaker 1: Self-managing hardware sounds cheaper, but the spreadsheet only works if utilisation stays high and change cadence slows down.
+Speaker 2: You now own spares, remote-hands visits, compliance paperwork and the upgrade roadmap—none of that shows up on the first invoice.
+Speaker 1: Make the shared-responsibility matrix explicit so the team knows who patches, who backs up and who gets paged when the power strip fails.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/11.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/11.md
@@ -1,0 +1,3 @@
+Speaker 1: Risk management changes with each model—serverless still needs exports, managed services need cross-region replicas, and racks need off-site backups.
+Speaker 2: Vendor exit plans can't just be "download the data." Capture infrastructure as code, schema migrations and performance benchmarks so switching is rehearsed.
+Speaker 1: And keep a shared-responsibility matrix handy; knowing whether the provider or your team handles identity, patching and incident response stops finger-pointing when things break.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/12.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/12.md
@@ -1,0 +1,3 @@
+Speaker 1: The repeat offenders? Shipping a bespoke Kubernetes stack before you have paying customers.
+Speaker 2: Or ignoring data transfer fees—egress between regions can erase any savings you thought you negotiated.
+Speaker 1: And never assume "the cloud will just scale." Without budgets and guardrails, you wake up to runaway spend and throttled APIs.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/13.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/13.md
@@ -1,0 +1,3 @@
+Speaker 1: Take Company X—they launched with three engineers on serverless functions and rode that model to a million users.
+Speaker 2: As workloads stabilised, they shifted core APIs to managed Kubernetes, then added two colocated edge sites at ten million users to meet latency SLAs.
+Speaker 1: Four years later, headcount hit fifteen, credits were gone, and they negotiated enterprise contracts—because operating models evolve with scale.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/14.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/14.md
@@ -1,0 +1,3 @@
+Speaker 1: Wrap it up with homework—run the cloud pricing calculators with your real numbers and growth bets.
+Speaker 2: Set billing alerts now, not after finance sees a five-figure surprise, and document the architecture assumptions you’re making today.
+Speaker 1: Pair that with a RACI chart and exit criteria so when the next funding round lands, you already know how to evolve the stack.

--- a/content/part-06/cloud-vs-on-premise-decisions/narratives/outline.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/narratives/outline.md
@@ -1,9 +1,10 @@
 # Narrative Outline — Cloud vs On-Premise Decisions
 
 ## Tasks
-- [ ] Compare the trade-offs between serverless options, managed services and self-managed infrastructure.
-- [ ] Highlight how AWS, Azure and GCP startup credits influence the decision path.
-- [ ] Frame questions founders should ask before committing to containers or keeping everything in the cloud.
+- [x] Compare the trade-offs between serverless options, managed services and self-managed infrastructure.
+- [x] Highlight how AWS, Azure and GCP startup credits influence the decision path.
+- [x] Frame questions founders should ask before committing to containers or keeping everything in the cloud.
 
 ## Notes
 - Evaluate free tiers across major cloud providers and when to adopt containers versus staying serverless.
+- Emphasise funding milestone checkpoints so teams revisit total cost of ownership and operational readiness.

--- a/content/part-06/cloud-vs-on-premise-decisions/slides.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/slides.md
@@ -15,6 +15,14 @@ title: Cloud vs On-Premise Decisions
 
 ---
 
+## Glossary: terms you'll hear
+- **SaaS / PaaS / IaaS:** Software, Platform and Infrastructure as a Service—progressively more control, but also more responsibility.
+- **SRE (Site Reliability Engineering):** The discipline focused on keeping services available and reliable through automation and operations rigor.
+- **Colocation vs on-premise:** Colocation rents space and power in a professional data centre; on-premise means hardware lives in your own facility.
+- **Reserved instances vs pay-as-you-go:** Commit to long-term usage for discounts, or pay on-demand for flexibility.
+
+---
+
 ## Startup runway vs operational overhead
 - **Months 0–12:** Prioritise velocity, keep the team shipping features and leverage managed services with generous free tiers.
 - **Year 2:** As usage grows, weigh predictable reserved cloud spend against the fixed costs of leased hardware and support staff.
@@ -24,29 +32,54 @@ title: Cloud vs On-Premise Decisions
 
 ## Serverless first: when it shines
 - No infrastructure patching, and scaling is automatic—perfect for small teams without SRE coverage.
-- Pay-per-use keeps experimentation cheap while you iterate on product-market fit.
-- Lock-in risk is mitigated by designing around open APIs and exporting data regularly.
+- Pay-per-use keeps experimentation cheap while you iterate on product-market fit; a food delivery beta with ~100 users might run $50/month.
+- Lock-in risk is mitigated by designing around open APIs, exporting data regularly and scripting data replays into alternative services.
 
 ---
 
 ## Managed cloud services: middle ground
-- Managed Kubernetes, database services and VDI stacks offload maintenance but still offer configuration control.
-- Use infrastructure as code to keep portability—document the baseline so you can recreate it elsewhere.
-- Factor in support plans; the first pager still belongs to your team even if the provider handles hardware.
+- That serverless approach we just discussed? Managed services are the nearby cousin when you outgrow simple functions but still want rapid delivery.
+- Managed Kubernetes, database services and VDI stacks offload maintenance but still offer configuration control when paired with infrastructure as code.
+- Factor in support plans and runbooks; the first pager still belongs to your team even if the provider handles hardware, network and backups.
 
 ---
 
-## Containers or self-managed: read the fine print
+## Decision helper
+```
+Start here → Need usable prototype in <5 minutes?
+        │               ├─ Yes → Stay serverless / SaaS
+        │               └─ No
+        ↓
+Team smaller than 3 engineers?
+        │               ├─ Yes → Lean on managed services
+        │               └─ No
+        ↓
+Strict compliance / data residency?
+        │               ├─ Yes → Plan hybrid / colocation footprint
+        │               └─ No → Keep optimising cloud setup
+```
+
+---
+
+## Containers: deceptively complex
 - Containers demand observability, image pipelines, security scanning and registry hygiene—skills many pre-Series A teams lack.
+- Treat the platform as a product: budget time for cluster upgrades, policy automation and chaos testing.
+- It's like deciding to brew your own coffee when you haven't figured out how to work the office coffee machine yet.
+
+---
+
+## Self-managed infrastructure: read the fine print
 - Self-hosting can cut per-unit costs once workloads stabilise, but only if utilisation stays high and change frequency slows.
-- Budget for redundant hardware, spares, remote hands at the data centre and compliance audits.
+- Budget for redundant hardware, spares, remote hands at the data centre and compliance audits before declaring savings.
+- Document shared responsibility: your team now owns patching, access reviews, backups and capacity upgrades end-to-end.
 
 ---
 
 ## Free tiers and startup credits
 - AWS Activate, Azure for Startups and Google Cloud credits can cover six figures of spend—plan workloads to maximise the runway.
-- Track expiry dates and graduation thresholds; sudden bills post-credit are a common failure mode.
-- Mix in SaaS with generous free tiers (Cloudflare, Auth0, Notion) to avoid burning credits on commodity services.
+- Track expiry dates and graduation thresholds; AWS Activate credits, for example, expire after two years or when you raise a Series A—whichever comes first.
+- Mix in SaaS with generous free tiers (Cloudflare's free CDN, Auth0's 7,000-user tier, Notion's unlimited personal plan) to avoid burning credits on commodity services.
+- Sudden bills post-credit are a common failure mode—also known as the "Oh no, we forgot we're not still in free tier" moment that ruins a founder's Tuesday.
 
 ---
 
@@ -54,6 +87,14 @@ title: Cloud vs On-Premise Decisions
 - Do we have repeatable CI/CD with automated tests and security scanning in place?
 - Can we monitor, patch and respond to incidents 24/7 without burning out a three-person engineering team?
 - Are there regulatory or customer requirements that truly block managed services?
+- Spoiler alert: if your "on-call rotation" is just Sarah checking her phone during dinner, the answer is no.
+
+---
+
+## Risk management across models
+- Define backup cadences: serverless databases still need export jobs, managed services benefit from cross-region replicas, and co-lo gear needs off-site copies.
+- Plan vendor exit ramps beyond raw data dumps—capture infrastructure as code, schema migrations and replacement service benchmarks.
+- Clarify shared responsibility matrices so you know who owns identity, patching, incident response and security testing in each model.
 
 ---
 
@@ -61,5 +102,26 @@ title: Cloud vs On-Premise Decisions
 - Reassess architecture at each funding milestone—seed, Series A, Series B—to confirm the stack matches burn rate and talent.
 - Run total cost of ownership models that include people, tooling, vendor support and opportunity cost of slower delivery.
 - Prototype exit ramps: document how to move a workload between serverless, managed and self-hosted so switching is a deliberate move, not a panic.
+
+---
+
+## Common mistakes to avoid
+- Over-engineering early architecture with bespoke Kubernetes before validating demand.
+- Ignoring data transfer and egress costs between regions or providers when forecasting spend.
+- Assuming "cloud = infinite scale" without designing guardrails, budgets and auto-scaling limits.
+
+---
+
+## Case study snapshot
+- "Company X" launched on serverless functions with a 3-person team, reaching 1M users before adopting managed Kubernetes for steady workloads.
+- By year four and 10M users, they added edge servers in two colocated facilities to meet latency SLAs while keeping the rest in cloud services.
+- Headcount grew from 3 to 15 engineers, and tooling spend shifted from credits to negotiated enterprise contracts.
+
+---
+
+## Practical next steps
+- Experiment with AWS, Azure and GCP pricing calculators to model 12–24 month costs under different growth assumptions.
+- Set up billing alerts and anomaly detection on day one so credits and budgets are visible to engineering and finance.
+- Document current architecture assumptions, RACI charts and exit criteria before you scale into the next operating model.
 
 ---

--- a/content/part-06/cloud-vs-on-premise-decisions/slides.md
+++ b/content/part-06/cloud-vs-on-premise-decisions/slides.md
@@ -4,5 +4,62 @@ title: Cloud vs On-Premise Decisions
 ---
 
 # Cloud vs On-Premise Decisions
+*Finding the right fit from day zero to scale*
+
+---
+
+## What this decision really covers
+- Application hosting, data storage, networking and identity services—each can live in SaaS, managed cloud or your own racks.
+- Early-stage teams juggle credit offers, compliance expectations and the talent they can actually hire to run the stack.
+- The "on-prem" option today often means co-lo racks or edge appliances managed by vendors, not a server closet you wire yourself.
+
+---
+
+## Startup runway vs operational overhead
+- **Months 0–12:** Prioritise velocity, keep the team shipping features and leverage managed services with generous free tiers.
+- **Year 2:** As usage grows, weigh predictable reserved cloud spend against the fixed costs of leased hardware and support staff.
+- **Year 3+:** Hybrid patterns emerge—latency-sensitive workloads or data residency demands may justify colocated gear, while the rest stays cloud-native.
+
+---
+
+## Serverless first: when it shines
+- No infrastructure patching, and scaling is automatic—perfect for small teams without SRE coverage.
+- Pay-per-use keeps experimentation cheap while you iterate on product-market fit.
+- Lock-in risk is mitigated by designing around open APIs and exporting data regularly.
+
+---
+
+## Managed cloud services: middle ground
+- Managed Kubernetes, database services and VDI stacks offload maintenance but still offer configuration control.
+- Use infrastructure as code to keep portability—document the baseline so you can recreate it elsewhere.
+- Factor in support plans; the first pager still belongs to your team even if the provider handles hardware.
+
+---
+
+## Containers or self-managed: read the fine print
+- Containers demand observability, image pipelines, security scanning and registry hygiene—skills many pre-Series A teams lack.
+- Self-hosting can cut per-unit costs once workloads stabilise, but only if utilisation stays high and change frequency slows.
+- Budget for redundant hardware, spares, remote hands at the data centre and compliance audits.
+
+---
+
+## Free tiers and startup credits
+- AWS Activate, Azure for Startups and Google Cloud credits can cover six figures of spend—plan workloads to maximise the runway.
+- Track expiry dates and graduation thresholds; sudden bills post-credit are a common failure mode.
+- Mix in SaaS with generous free tiers (Cloudflare, Auth0, Notion) to avoid burning credits on commodity services.
+
+---
+
+## Questions before jumping to containers
+- Do we have repeatable CI/CD with automated tests and security scanning in place?
+- Can we monitor, patch and respond to incidents 24/7 without burning out a three-person engineering team?
+- Are there regulatory or customer requirements that truly block managed services?
+
+---
+
+## Decision checkpoints
+- Reassess architecture at each funding milestone—seed, Series A, Series B—to confirm the stack matches burn rate and talent.
+- Run total cost of ownership models that include people, tooling, vendor support and opportunity cost of slower delivery.
+- Prototype exit ramps: document how to move a workload between serverless, managed and self-hosted so switching is a deliberate move, not a panic.
 
 ---


### PR DESCRIPTION
## Summary
- add detailed slides on cloud versus on-premise decision factors for startups
- provide supporting narratives covering serverless, managed services, credits and readiness checks
- update the to-do list to mark the cloud versus on-premise content as complete

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68db70b2553883258cf9c933222cf19a