### PR TITLE
Add day-zero assessment checklist materials

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -107,7 +107,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Capstone red team group exercise structure and maturity model mapping activity
   - [x] Draft slides and narrative: Capstone remediation roadmap with take-home planning and reflection prompts
   - [x] Draft slides and narrative: Cloud versus on-premise decisions, including free tier comparisons and container adoption timing
-  - [ ] Draft slides and narrative: Day zero assessment checklist covering identity, endpoint, backup and security controls
+  - [x] Draft slides and narrative: Day zero assessment checklist covering identity, endpoint, backup and security controls
   - [ ] Draft slides and narrative: Day zero core services setup—from incorporation and domains to devices—with Sarah's DNS cautionary tale
   - [ ] Draft slides and narrative: Fractional CTO and MSP partnership models with evaluation questions
   - [ ] Draft slides and narrative: Guest speaker ideas and the perspectives they bring to the session

--- a/content/part-06/day-zero-assessment-checklist/narratives/01.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/01.md
@@ -1,4 +1,4 @@
 Speaker 1: [energetic] Before the first hire signs their offer letter, founders are already juggling payroll, domains and customer trials.
-Speaker 2: Right, and every shortcut we take with accounts or laptops in those first 48 hours becomes technical and security debt a month later.
+Speaker 2: Right, and every shortcut we take with accounts or laptops in those first 48 hours becomes technical debt that haunts us like a badly written contract with your co-founder's cousin.
 Speaker 1: That is why we open with a day-zero checklist—it freezes the chaos long enough to get intentional about who can touch what.
 Speaker 2: And once it exists, you can run the same play every time a new teammate or contractor joins instead of improvising access in Slack DMs.

--- a/content/part-06/day-zero-assessment-checklist/narratives/01.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/01.md
@@ -1,0 +1,4 @@
+Speaker 1: [energetic] Before the first hire signs their offer letter, founders are already juggling payroll, domains and customer trials.
+Speaker 2: Right, and every shortcut we take with accounts or laptops in those first 48 hours becomes technical and security debt a month later.
+Speaker 1: That is why we open with a day-zero checklist—it freezes the chaos long enough to get intentional about who can touch what.
+Speaker 2: And once it exists, you can run the same play every time a new teammate or contractor joins instead of improvising access in Slack DMs.

--- a/content/part-06/day-zero-assessment-checklist/narratives/02.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/02.md
@@ -1,0 +1,4 @@
+Speaker 1: [practical] When you run the workshop, block 90 minutes and invite the people who actually flip the switches—founders, ops, any MSP partner.
+Speaker 2: I like to start by drawing the current system map on a whiteboard. Seeing payroll tied to the bank, CRM feeding support, it grounds the conversation.
+Speaker 1: Then nominate a scribe. Someone updates the checklist in real time so “we should enable MFA” instantly becomes an owner plus due date.
+Speaker 2: And before you move on, pause to log blockers—missing licenses, unclear vendor contacts—so they feed straight into Jira, Asana or the trusty spreadsheet.

--- a/content/part-06/day-zero-assessment-checklist/narratives/02.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/02.md
@@ -1,4 +1,4 @@
 Speaker 1: [practical] When you run the workshop, block 90 minutes and invite the people who actually flip the switches—founders, ops, any MSP partner.
 Speaker 2: I like to start by drawing the current system map on a whiteboard. Seeing payroll tied to the bank, CRM feeding support, it grounds the conversation.
 Speaker 1: Then nominate a scribe. Someone updates the checklist in real time so “we should enable MFA” instantly becomes an owner plus due date.
-Speaker 2: And before you move on, pause to log blockers—missing licenses, unclear vendor contacts—so they feed straight into Jira, Asana or the trusty spreadsheet.
+Speaker 2: And before you move on, pause to log blockers—missing licenses, unclear vendor contacts—so they don't end up in the startup graveyard of “we really should get around to that someday.”

--- a/content/part-06/day-zero-assessment-checklist/narratives/03.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/03.md
@@ -1,0 +1,4 @@
+Speaker 1: [guiding] The checklist itself is four blocks: identity, endpoints, backups and security governance.
+Speaker 2: Give each line item a simple green, amber, red score. It keeps the conversation focused on risk instead of blame.
+Speaker 1: And remember to jot the system of record beside each control—Google Workspace, Okta, a password manager—so you know where truth lives.
+Speaker 2: That clarity also helps when you hand the assessment to a fractional CTO or MSP; they can instantly see the hotspots.

--- a/content/part-06/day-zero-assessment-checklist/narratives/04.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/04.md
@@ -1,0 +1,4 @@
+Speaker 1: [focused] Identity is first because every other control depends on who can log in where.
+Speaker 2: Map each tool back to your source of truth—HR roster, Google, Microsoft—and note whether MFA is enforced or still optional.
+Speaker 1: Document the joiner, mover, leaver steps including who removes access at 5pm when someone resigns abruptly.
+Speaker 2: And wherever you see shared logins or personal emails on vendor accounts, highlight them for legal to renegotiate before renewal.

--- a/content/part-06/day-zero-assessment-checklist/narratives/05.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/05.md
@@ -1,0 +1,4 @@
+Speaker 1: [methodical] Endpoints are next. Start with a live asset list—owner, device type, OS version, last patch date.
+Speaker 2: It can be a spreadsheet to begin with, just make sure someone owns keeping it current.
+Speaker 1: Record your baseline build: encryption on, screen lock, approved software. Consistency stops shadow IT before it spreads.
+Speaker 2: And check you can remote wipe or at least lock a laptop. Founders travel, gear gets left in rideshares—you need that fail-safe in place now.

--- a/content/part-06/day-zero-assessment-checklist/narratives/05.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/05.md
@@ -1,4 +1,4 @@
 Speaker 1: [methodical] Endpoints are next. Start with a live asset list—owner, device type, OS version, last patch date.
 Speaker 2: It can be a spreadsheet to begin with, just make sure someone owns keeping it current.
 Speaker 1: Record your baseline build: encryption on, screen lock, approved software. Consistency stops shadow IT before it spreads.
-Speaker 2: And check you can remote wipe or at least lock a laptop. Founders travel, gear gets left in rideshares—you need that fail-safe in place now.
+Speaker 2: And check you can remote wipe or at least lock a laptop. Founders travel, gear gets left in rideshares, and suddenly your company's most sensitive data is racing through downtown in someone else's Tesla.

--- a/content/part-06/day-zero-assessment-checklist/narratives/06.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/06.md
@@ -1,0 +1,4 @@
+Speaker 1: [analytical] For backups, identify the data that would hurt to lose—source code, CRM, finance, product telemetry.
+Speaker 2: Ask two questions: is there an automated backup, and when did we last test restoring it?
+Speaker 1: Capture how long the restore took and any surprises. That anecdote becomes gold when auditors or investors ask about resilience.
+Speaker 2: Also plan manual fallbacks—exporting CSVs, printing key docs—so the team can keep shipping even while a vendor is down.

--- a/content/part-06/day-zero-assessment-checklist/narratives/07.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/07.md
@@ -1,0 +1,4 @@
+Speaker 1: [cautious] The security and monitoring section ties everything together.
+Speaker 2: Review password policies, make sure default admin accounts are renamed, and log authentication events somewhere you can actually search.
+Speaker 1: Draft an incident contact tree now—who talks to investors, customers, regulators—so you are not scrambling mid-crisis.
+Speaker 2: And decide on vulnerability scanning cadence plus patch windows; expectations set early are easier to enforce later.

--- a/content/part-06/day-zero-assessment-checklist/narratives/08.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/08.md
@@ -1,0 +1,4 @@
+Speaker 1: [outcome-focused] By the end of the workshop you should have tangible outputs, not just a lively chat.
+Speaker 2: That means a scored checklist, a 30/60/90 plan, refreshed runbooks and a folder of evidence screenshots and policies.
+Speaker 1: Book the follow-up review before everyone leaves the room—ideally before the next hire or investor update.
+Speaker 2: Treat it like any other deliverable: assign owners, due dates, and drop the tasks into your project tracker right away.

--- a/content/part-06/day-zero-assessment-checklist/narratives/09.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/09.md
@@ -1,0 +1,4 @@
+Speaker 1: [career-minded] These assessments are often championed by fractional CTOs, security-savvy ops managers or MSP onboarding leads.
+Speaker 2: It is a fantastic shadowing opportunity for junior analysts—they learn facilitation, stakeholder translation and control baselining.
+Speaker 1: The real skill is empathy: explaining why MFA matters without sounding like the “no” police.
+Speaker 2: Nail that and you build the muscle to grow into head of IT, risk lead or customer trust advocate roles as the company scales.

--- a/content/part-06/day-zero-assessment-checklist/narratives/10.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/10.md
@@ -1,0 +1,4 @@
+Speaker 1: [encouraging] Keep the checklist alive; review it after every hire, vendor change or funding milestone.
+Speaker 2: When investors or auditors call, you already have evidence folders and owners lined up—it shifts the tone from defensive to confident.
+Speaker 1: More importantly, the team knows what “secure enough” looks like today and how it will mature tomorrow.
+Speaker 2: That shared playbook turns day-zero chaos into a calm, repeatable ritual that protects both momentum and trust.

--- a/content/part-06/day-zero-assessment-checklist/narratives/outline.md
+++ b/content/part-06/day-zero-assessment-checklist/narratives/outline.md
@@ -1,9 +1,9 @@
 # Narrative Outline — Day-Zero Startup IT Assessment
 
 ## Tasks
-- [ ] Design the interactive checklist covering identity, endpoints, backups and security toggles.
-- [ ] Explain how to facilitate the checklist as a live workshop activity.
-- [ ] Clarify outputs participants should walk away with after completing the assessment.
+- [x] Design the interactive checklist covering identity, endpoints, backups and security toggles.
+- [x] Explain how to facilitate the checklist as a live workshop activity.
+- [x] Clarify outputs participants should walk away with after completing the assessment.
 
 ## Notes
 - Draft the identity, endpoint, backup and security checklist used on day zero.

--- a/content/part-06/day-zero-assessment-checklist/slides.md
+++ b/content/part-06/day-zero-assessment-checklist/slides.md
@@ -11,6 +11,7 @@ title: Day-Zero Startup IT Assessment
 ## Why a day-zero checklist?
 - Founders are wiring payroll, domains and devices while investors expect security by default.
 - Early missteps compound: a shared admin login today becomes a breach notification tomorrow.
+- For instance, that shared “admin123” password for your accounting software that “everyone knows” becomes a $50K breach notification when a disgruntled contractor uses it six months after leaving.
 - A structured checklist turns tribal knowledge into a repeatable onboarding ritual for every new hire and contractor.
 - It also creates a baseline for MSP handovers, cyber insurance applications and due diligence conversations.
 
@@ -36,6 +37,7 @@ title: Day-Zero Startup IT Assessment
 ## Identity foundations
 - Map every system to an identity source: HR roster, Google Workspace, Microsoft 365, or a password manager.
 - Require MFA on admin, finance and customer data tools before inviting the next hire.
+- Picture this: your sales director leaves on Friday afternoon. Without documented processes, their Salesforce admin access, Slack ownership of customer channels, and shared Dropbox folders remain active over the weekend.
 - Document joiner/mover/leaver steps, including who revokes access when someone exits suddenly.
 - Capture shared secrets in a vault with rotation dates rather than in spreadsheets or chat threads.
 - Flag gaps like personal email accounts on vendor contracts so legal can renegotiate early.
@@ -54,9 +56,44 @@ title: Day-Zero Startup IT Assessment
 ## Backups and data protection
 - Identify critical data stores: source code, CRM, finance, shared drives and product telemetry.
 - Verify at least one automated backup exists with retention that meets contractual promises.
+- One startup lost three months of customer support tickets when their help desk vendor had a data center fire. They assumed “it’s SaaS, they handle backups” until the fine print said otherwise.
 - Test a sample restore quarterly and document who validated it, how long it took and what broke.
 - Outline manual fallback workflows—exporting CSVs, printing key documents, or switching to a secondary tool.
 - Track compliance drivers (tax, privacy, contracts) that dictate how long data must stay recoverable.
+
+---
+
+## Cloud-first vs. hybrid realities
+- Catalogue where workloads actually live: fully managed SaaS, cloud-native infrastructure or a closet server humming beside the coffee machine.
+- Cloud-first startups lean on identity providers and vendor assurances—validate export options and incident SLAs.
+- Hybrid environments demand network diagrams, VPN policies and clear ownership for patching on-prem gear.
+- Flag data residency constraints early; some investors or customers will demand proof of where data rests.
+
+---
+
+## Budget reality check
+- Triage controls by risk and runway: what must be solved with $500/month versus what waits for a $5K allocation.
+- Highlight quick wins—enforcing MFA, password managers, baseline device hardening—before pricier SIEMs or MDR contracts.
+- Map spend to milestones (Series A, first enterprise customer) so finance understands why costs jump.
+- Capture deferred items with explicit triggers: “Upgrade logging when monthly recurring revenue hits $250K.”
+
+---
+
+## Common day-zero pitfalls
+- Relying on personal Gmail accounts for vendor contracts and Stripe access.
+- Skipping device encryption because “it’s just a prototype laptop.”
+- Assuming vendors manage backups, incident response or compliance obligations without written proof.
+- Forgetting to offboard contractors, leaving privileged accounts active for months.
+- Treating security tasks as “best effort,” so they die in the backlog when sales gets hectic.
+
+---
+
+## Vendor due diligence quick wins
+- Create a lightweight intake form covering data stored, access model, compliance attestations and breach history.
+- Ask for security documentation (SOC 2, pen test summary) before signing, not after the renewal.
+- Verify termination clauses: how fast can you retrieve or purge data when the contract ends?
+- Add vendors to your asset and identity maps so joiner/leaver workflows catch shared integrations.
+- Keep a template questionnaire email ready to send the moment a new tool is proposed.
 
 ---
 
@@ -73,6 +110,9 @@ title: Day-Zero Startup IT Assessment
 - A scored checklist PDF or Notion page with red/amber/green status and named owners.
 - A 30/60/90-day roadmap of remediation tasks aligned to risk and business milestones.
 - Updated runbooks: account lifecycle, device setup, backup testing and escalation paths.
+- Template email scripts for vendor security questionnaires and customer assurances.
+- Starter policy templates (access control, device, incident response) ready for quick customization.
+- Quick-reference cards for emergency procedures—lost device, suspected phishing, production outage.
 - A shared folder with evidence—screenshots, policy links, vendor contracts—for future audits or funding rounds.
 - A follow-up session booked to review progress before the next hire or investor meeting.
 

--- a/content/part-06/day-zero-assessment-checklist/slides.md
+++ b/content/part-06/day-zero-assessment-checklist/slides.md
@@ -4,5 +4,90 @@ title: Day-Zero Startup IT Assessment
 ---
 
 # Day-Zero Startup IT Assessment
+*Make the first 48 hours intentional*
 
+---
+
+## Why a day-zero checklist?
+- Founders are wiring payroll, domains and devices while investors expect security by default.
+- Early missteps compound: a shared admin login today becomes a breach notification tomorrow.
+- A structured checklist turns tribal knowledge into a repeatable onboarding ritual for every new hire and contractor.
+- It also creates a baseline for MSP handovers, cyber insurance applications and due diligence conversations.
+
+---
+
+## Facilitating the workshop
+- Schedule a 90-minute working session with the founding team, operations lead and any fractional IT partner.
+- Start with a current-state mural or whiteboard of systems before diving into controls—people grasp context first.
+- Assign a scribe who updates the checklist live so decisions turn into action items instead of hallway promises.
+- Close each section by capturing blockers, owners and due dates to feed your task tracker that same afternoon.
+
+---
+
+## Checklist structure at a glance
+- **Identity** – who has access, how accounts are created, and where MFA is enforced.
+- **Endpoints** – device inventory, hardening steps and remote wipe readiness.
+- **Backups & Continuity** – what data is protected, tested restores and manual fallbacks.
+- **Security & Governance** – logging, password policies, vendor reviews and incident contacts.
+- Each block should score readiness (green/amber/red) to signal where to focus limited time and budget.
+
+---
+
+## Identity foundations
+- Map every system to an identity source: HR roster, Google Workspace, Microsoft 365, or a password manager.
+- Require MFA on admin, finance and customer data tools before inviting the next hire.
+- Document joiner/mover/leaver steps, including who revokes access when someone exits suddenly.
+- Capture shared secrets in a vault with rotation dates rather than in spreadsheets or chat threads.
+- Flag gaps like personal email accounts on vendor contracts so legal can renegotiate early.
+
+---
+
+## Endpoint readiness
+- Build an asset list with owner, device type, OS version, and last patch date—spreadsheets beat wishful thinking.
+- Standardise baseline builds: disk encryption, auto-lock timers, and approved software images.
+- Enable remote wipe or MDM for laptops and mobile phones before a travel-heavy sales push.
+- Confirm antivirus/EDR coverage and define how alerts route to whoever is on-call.
+- Note loaner device processes so day-one hires are not waiting on procurement.
+
+---
+
+## Backups and data protection
+- Identify critical data stores: source code, CRM, finance, shared drives and product telemetry.
+- Verify at least one automated backup exists with retention that meets contractual promises.
+- Test a sample restore quarterly and document who validated it, how long it took and what broke.
+- Outline manual fallback workflows—exporting CSVs, printing key documents, or switching to a secondary tool.
+- Track compliance drivers (tax, privacy, contracts) that dictate how long data must stay recoverable.
+
+---
+
+## Security controls and monitoring
+- Review password policies, SSO coverage and whether default admin accounts have been renamed or disabled.
+- Confirm logging is enabled for auth events, financial transactions and production infrastructure.
+- Establish an incident contact tree with who calls legal, PR, investors and affected customers.
+- Set expectations for vulnerability scanning cadence and patch response windows.
+- Capture third-party vendor attestations (SOC 2, ISO 27001) and note renewals on the calendar.
+
+---
+
+## Workshop outputs
+- A scored checklist PDF or Notion page with red/amber/green status and named owners.
+- A 30/60/90-day roadmap of remediation tasks aligned to risk and business milestones.
+- Updated runbooks: account lifecycle, device setup, backup testing and escalation paths.
+- A shared folder with evidence—screenshots, policy links, vendor contracts—for future audits or funding rounds.
+- A follow-up session booked to review progress before the next hire or investor meeting.
+
+---
+
+## Roles, traits and progression
+- Day-zero assessments are often led by fractional CTOs, security-minded operations managers or MSP onboarding leads.
+- Junior security analysts and IT generalists can shadow to learn stakeholder facilitation and control baselining.
+- Success hinges on curiosity, diplomacy and the ability to translate checkboxes into founder-friendly language.
+- As the company scales, these practitioners grow into heads of IT, risk leaders or customer trust advocates with board visibility.
+- Encourage cross-functional allies—finance, HR, product—to own portions of the checklist so accountability is shared.
+
+---
+
+## Key takeaway
+A living day-zero checklist is your startup's safety net. It keeps identity, devices, backups and security posture honest from the outset, making future audits and incidents far less dramatic.
+Treat the artefact as a shared playbook: iterate after every hire, vendor change or funding round so resilience matures alongside revenue.
 ---


### PR DESCRIPTION
## Summary
- create day-zero startup IT assessment slides covering identity, endpoint, backup and security controls
- add supporting workshop narrative scripts and update the outline checklist tasks
- mark the curriculum to-do item for completing the day-zero assessment materials as complete

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdead87cc832580c0196d5d94b36e