### PR TITLE
Add day-zero core services setup materials

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -108,7 +108,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Capstone remediation roadmap with take-home planning and reflection prompts
   - [x] Draft slides and narrative: Cloud versus on-premise decisions, including free tier comparisons and container adoption timing
   - [x] Draft slides and narrative: Day zero assessment checklist covering identity, endpoint, backup and security controls
-  - [ ] Draft slides and narrative: Day zero core services setup—from incorporation and domains to devices—with Sarah's DNS cautionary tale
+  - [x] Draft slides and narrative: Day zero core services setup—from incorporation and domains to devices—with Sarah's DNS cautionary tale
   - [ ] Draft slides and narrative: Fractional CTO and MSP partnership models with evaluation questions
   - [ ] Draft slides and narrative: Guest speaker ideas and the perspectives they bring to the session
   - [ ] Draft slides and narrative: Investor due diligence preparation, red flags and policy-to-board mapping tips

--- a/content/part-06/day-zero-core-services/narratives/01-intro.md
+++ b/content/part-06/day-zero-core-services/narratives/01-intro.md
@@ -1,0 +1,4 @@
+Speaker 1: Day-zero sounds dramatic, but it's literally the first five business days.
+Speaker 2: Exactly—incorporation, domains, devices and security all race to go live together.
+Speaker 1: Miss a step and you're chasing paperwork while customers wait.
+Speaker 2: So we map the whole week before the first hire even signs their contract.

--- a/content/part-06/day-zero-core-services/narratives/02-day-zero-scope.md
+++ b/content/part-06/day-zero-core-services/narratives/02-day-zero-scope.md
@@ -1,0 +1,4 @@
+Speaker 1: What's actually included in this "day-zero" checklist?
+Speaker 2: Anything that makes the company real—legal filings, domains, baseline tooling and who owns each task.
+Speaker 1: So it's not just IT running off to configure email.
+Speaker 2: Right, it's a cross-functional sprint with evidence you can show an MSP, investor or auditor.

--- a/content/part-06/day-zero-core-services/narratives/03-incorporation-registrations.md
+++ b/content/part-06/day-zero-core-services/narratives/03-incorporation-registrations.md
@@ -1,4 +1,6 @@
 Speaker 1: We start with the boring stuff: entity registration and bank accounts.
 Speaker 2: Boring until a contractor asks for payment and you realise payroll IDs aren't ready.
+Speaker 2: Or until a contractor sends an invoice and you discover "Awesome Startup LLC" was never actually registered.
+Speaker 1: Nothing kills the entrepreneur vibe faster than admitting you're technically a sole proprietorship.
 Speaker 1: Or a founder leaves and there was never a signed agreement.
 Speaker 2: That's why day-zero includes a data room folder for all those artefacts.

--- a/content/part-06/day-zero-core-services/narratives/03-incorporation-registrations.md
+++ b/content/part-06/day-zero-core-services/narratives/03-incorporation-registrations.md
@@ -1,0 +1,4 @@
+Speaker 1: We start with the boring stuff: entity registration and bank accounts.
+Speaker 2: Boring until a contractor asks for payment and you realise payroll IDs aren't ready.
+Speaker 1: Or a founder leaves and there was never a signed agreement.
+Speaker 2: That's why day-zero includes a data room folder for all those artefacts.

--- a/content/part-06/day-zero-core-services/narratives/04-domains-dns.md
+++ b/content/part-06/day-zero-core-services/narratives/04-domains-dns.md
@@ -1,4 +1,6 @@
 Speaker 1: Domains feel simple—just buy the .com and you're done, right?
 Speaker 2: Until someone forgets the .co or country code and a squatter grabs it.
+Speaker 1: Or when the CEO's ex-partner controls the domain and decides to get creative during the breakup.
+Speaker 2: That's why we register defensives—and use business email, not the founder's hotmail-from-college account.
 Speaker 1: Or the registrar is tied to a personal Gmail account you can't access during travel.
 Speaker 2: Shared ops email, templated DNS records and uptime monitoring keep launches from face-planting.

--- a/content/part-06/day-zero-core-services/narratives/04-domains-dns.md
+++ b/content/part-06/day-zero-core-services/narratives/04-domains-dns.md
@@ -1,0 +1,4 @@
+Speaker 1: Domains feel simple—just buy the .com and you're done, right?
+Speaker 2: Until someone forgets the .co or country code and a squatter grabs it.
+Speaker 1: Or the registrar is tied to a personal Gmail account you can't access during travel.
+Speaker 2: Shared ops email, templated DNS records and uptime monitoring keep launches from face-planting.

--- a/content/part-06/day-zero-core-services/narratives/05-productivity-identity.md
+++ b/content/part-06/day-zero-core-services/narratives/05-productivity-identity.md
@@ -1,0 +1,4 @@
+Speaker 1: Choosing Google Workspace versus Microsoft 365 still sparks debates.
+Speaker 2: The real question is which ecosystem your customers expect and what integrates with your stack.
+Speaker 1: Either way, MFA on admin roles and shared mailboxes can't wait a month.
+Speaker 2: And even if HR is a spreadsheet, sync it so joiners and leavers stay in lockstep.

--- a/content/part-06/day-zero-core-services/narratives/06-communication-knowledge.md
+++ b/content/part-06/day-zero-core-services/narratives/06-communication-knowledge.md
@@ -1,0 +1,4 @@
+Speaker 1: Where do we keep the policies and meeting notes so they don't vanish in chat history?
+Speaker 2: Spin up a knowledge base on day one, even if it's a single-page Notion workspace.
+Speaker 1: And pre-build channels for incidents, board updates and customer escalations.
+Speaker 2: Templates save teams from reinventing emails at 2 a.m. when something breaks.

--- a/content/part-06/day-zero-core-services/narratives/07-device-setup.md
+++ b/content/part-06/day-zero-core-services/narratives/07-device-setup.md
@@ -1,0 +1,4 @@
+Speaker 1: Hardware always turns up late unless you plan buffers.
+Speaker 2: Exactly—keep a few imaged laptops ready with asset tags and shipping labels.
+Speaker 1: And don't forget travel kits for sales or fundraising trips.
+Speaker 2: Record serials and warranties so replacements aren't a scavenger hunt.

--- a/content/part-06/day-zero-core-services/narratives/07-device-setup.md
+++ b/content/part-06/day-zero-core-services/narratives/07-device-setup.md
@@ -1,4 +1,6 @@
 Speaker 1: Hardware always turns up late unless you plan buffers.
 Speaker 2: Exactly—keep a few imaged laptops ready with asset tags and shipping labels.
+Speaker 1: And there's always one founder who insists on a $4,000 gaming laptop "for better performance."
+Speaker 2: Which promptly gets coffee spilled on it during the first investor meeting.
 Speaker 1: And don't forget travel kits for sales or fundraising trips.
 Speaker 2: Record serials and warranties so replacements aren't a scavenger hunt.

--- a/content/part-06/day-zero-core-services/narratives/08-security-guardrails.md
+++ b/content/part-06/day-zero-core-services/narratives/08-security-guardrails.md
@@ -1,0 +1,4 @@
+Speaker 1: Security feels like overkill before the first customer signs.
+Speaker 2: Yet that's when attackers love to strike—defaults are still wide open.
+Speaker 1: So we turn on password managers, logging and break-glass accounts immediately.
+Speaker 2: And make sure founders know who to call—lawyers, insurers, incident responders—if something goes sideways.

--- a/content/part-06/day-zero-core-services/narratives/09-sarah-dns-story.md
+++ b/content/part-06/day-zero-core-services/narratives/09-sarah-dns-story.md
@@ -1,0 +1,4 @@
+Speaker 1: Remind me about Sarah's DNS incident—you keep telling teams that story.
+Speaker 2: She registered the domain with her personal email, deleted a wildcard record at 1 a.m. and the demo site vanished for six hours.
+Speaker 1: Investors called before breakfast and the sales team had to reschedule every meeting.
+Speaker 2: Now she keeps registrar access in a shared vault with change windows, even with ten employees.

--- a/content/part-06/day-zero-core-services/narratives/10-runbook.md
+++ b/content/part-06/day-zero-core-services/narratives/10-runbook.md
@@ -1,0 +1,4 @@
+Speaker 1: How do we keep momentum once the checklist starts?
+Speaker 2: Daily stand-ups, a Kanban board and a link to evidence for every completed task.
+Speaker 1: Plus async walkthrough videos so the next hire isn't blocked waiting for a founder.
+Speaker 2: And note which lawyers, accountants or MSPs you escalate to if things stall.

--- a/content/part-06/day-zero-core-services/narratives/11-takeaway.md
+++ b/content/part-06/day-zero-core-services/narratives/11-takeaway.md
@@ -1,0 +1,4 @@
+Speaker 1: So the goal is confidence that core services survive founder vacations and audits.
+Speaker 2: Exactly—treat day-zero as a living runbook, not a one-off launch party.
+Speaker 1: When everything's documented, due diligence calls become show-and-tell.
+Speaker 2: And the team can focus on customers instead of chasing missing DNS logins.

--- a/content/part-06/day-zero-core-services/narratives/outline.md
+++ b/content/part-06/day-zero-core-services/narratives/outline.md
@@ -1,9 +1,9 @@
 # Narrative Outline — Day-Zero Core Services Setup
 
 ## Tasks
-- [ ] Map the first-week tasks for incorporating the company and provisioning core services.
-- [ ] Explain choices for domain registration, productivity suites and lightweight device procurement.
-- [ ] Weave in Sarah's "CEO learns DNS the hard way" cautionary tale as a teaching beat.
+- [x] Map the first-week tasks for incorporating the company and provisioning core services.
+- [x] Explain choices for domain registration, productivity suites and lightweight device procurement.
+- [x] Weave in Sarah's "CEO learns DNS the hard way" cautionary tale as a teaching beat.
 
 ## Notes
 - Outline company incorporation steps, domain registration, productivity suite choices and device procurement basics, including Sarah's DNS cautionary tale.

--- a/content/part-06/day-zero-core-services/slides.md
+++ b/content/part-06/day-zero-core-services/slides.md
@@ -34,6 +34,8 @@ title: Day-Zero Core Services Setup
 
 ## Productivity suite and identity backbone
 - Choose Google Workspace or Microsoft 365 based on customer expectations and toolchain fit
+- Example: a B2B SaaS startup picked Google Workspace because enterprise buyers expected Google SSO integration
+- Compare costs early—Google Workspace Business Standard at $12/user/month vs Microsoft 365 Business Premium at $22/user/month
 - Establish a primary identity provider and enforce MFA on admin roles from day one
 - Create shared mailboxes (hello@, finance@) and delegated calendar access for founders
 - Sync HR roster or interim spreadsheet to drive joiner/mover/leaver workflows
@@ -50,6 +52,8 @@ title: Day-Zero Core Services Setup
 
 ## Device procurement and setup
 - Order a buffer of laptops with baseline images, asset tags and shipping templates
+- Plan inventory—for a two-person team, order three laptops so a backup is ready for demos or travel hiccups
+- Budget $1,500–2,000 per laptop including warranty, MDM licensing and shipping
 - Pre-stage admin accounts in MDM or Autopilot/Zero Touch before boxes leave the supplier
 - Document loaner process plus travel kits (power adapters, privacy filters, LTE dongles)
 - Track serial numbers, warranty dates and assigned owners in the asset register
@@ -60,7 +64,30 @@ title: Day-Zero Core Services Setup
 - Enable password manager, phishing reporting button and security awareness bite-size modules
 - Turn on default logging, backup policies and conditional access before inviting new users
 - Generate break-glass accounts with hardware keys stored off-site under dual control
+- Recommend starter tooling: 1Password for teams ($8/user/month), Microsoft Defender for Business or Google Workspace security center
 - Add founders to incident bridge, legal counsel and cyber insurer contact lists
+
+---
+
+## Budgeting for day-zero services
+- Reserve $200–500/month for productivity suite licensing, domain registration and DNS hosting
+- Allow 2–3 weeks for hardware procurement, imaging and inevitable shipping delays
+- Line up $1,000–3,000 for incorporation legal fees plus trademark searches
+- Pre-approve founder credit cards so vendor sign-ups are not stalled at payment screens
+
+---
+
+## Early compliance and data residency
+- Confirm whether early contracts mandate specific data locations or certifications
+- Document which services store data in which regions (e.g. Slack US, email EU) to avoid surprises
+- Draft a lightweight privacy policy before collecting any customer information
+- Flag GDPR, CCPA or industry rules that influence vendor shortlists and architecture choices
+
+---
+
+## When day-zero planning goes wrong
+Real examples teach better than theoretical checklists.
+Let's see how a simple DNS mistake nearly derailed a promising startup.
 
 ---
 
@@ -83,5 +110,6 @@ title: Day-Zero Core Services Setup
 ## Key takeaway
 A disciplined day-zero setup makes incorporation, domains, devices and security feel intentional.
 Treat the checklist as a living runbook that survives founder vacations, vendor turnover and the first due-diligence call.
+Your assignment: craft a day-zero checklist for a hypothetical startup, noting where outside experts are required.
 
 ---

--- a/content/part-06/day-zero-core-services/slides.md
+++ b/content/part-06/day-zero-core-services/slides.md
@@ -4,5 +4,84 @@ title: Day-Zero Core Services Setup
 ---
 
 # Day-Zero Core Services Setup
+*Launch the company without losing the first week*
+
+---
+
+## What "day zero" covers
+- Incorporation paperwork, domains, devices and baseline tooling
+- Mapping who owns which setup tasks during the first 5 business days
+- Getting identity, communication and knowledge systems online together
+- Capturing decisions so MSPs, investors and auditors see a coherent plan
+
+---
+
+## Incorporation & registrations
+- Lodge the legal entity, appoint directors and open a business bank account
+- Secure tax IDs and payroll registration before the first contractor invoice lands
+- Document ownership structure and sign founder agreements to prevent later disputes
+- Create a data room folder for incorporation artefacts and board resolutions
+
+---
+
+## Domains, DNS and website plumbing
+- Register primary domains plus defensives (.com, .co, relevant country codes)
+- Use registrar accounts tied to shared ops email, not a founder's personal inbox
+- Set up DNS hosting with templated records for MX, SPF, DKIM and verification tokens
+- Configure uptime monitoring so a silent DNS change does not break email launches
+
+---
+
+## Productivity suite and identity backbone
+- Choose Google Workspace or Microsoft 365 based on customer expectations and toolchain fit
+- Establish a primary identity provider and enforce MFA on admin roles from day one
+- Create shared mailboxes (hello@, finance@) and delegated calendar access for founders
+- Sync HR roster or interim spreadsheet to drive joiner/mover/leaver workflows
+
+---
+
+## Communication and knowledge hubs
+- Stand up chat (Slack/Teams) with channels for founders, delivery, customers and incidents
+- Launch a lightweight knowledge base (Notion, Confluence, Google Sites) for policies and SOPs
+- Decide where meeting notes, board decks and investor updates live to avoid scattered history
+- Pre-create announcement, incident and customer escalation templates for fast reuse
+
+---
+
+## Device procurement and setup
+- Order a buffer of laptops with baseline images, asset tags and shipping templates
+- Pre-stage admin accounts in MDM or Autopilot/Zero Touch before boxes leave the supplier
+- Document loaner process plus travel kits (power adapters, privacy filters, LTE dongles)
+- Track serial numbers, warranty dates and assigned owners in the asset register
+
+---
+
+## Security guardrails on hour one
+- Enable password manager, phishing reporting button and security awareness bite-size modules
+- Turn on default logging, backup policies and conditional access before inviting new users
+- Generate break-glass accounts with hardware keys stored off-site under dual control
+- Add founders to incident bridge, legal counsel and cyber insurer contact lists
+
+---
+
+## Sarah's DNS cautionary tale
+- Sarah, the CEO, registered the domain under her personal email and "learned DNS" at 1 a.m.
+- She deleted the wildcard record while experimenting, taking product demos offline for 6 hours
+- Sales woke up to bounced customer emails and a frantic investor asking about the outage
+- The fix: shared registrar access, documented records and change windows even for tiny teams
+
+---
+
+## First-week runbook
+- Create a simple Kanban board with day-zero tasks, owners and completion evidence links
+- Schedule daily 15-minute stand-ups to clear blockers and surface vendor delays
+- Record walkthrough videos for critical systems so future hires ramp without live hand-holding
+- Note dependencies on lawyers, accountants or MSPs and pre-book escalation contacts
+
+---
+
+## Key takeaway
+A disciplined day-zero setup makes incorporation, domains, devices and security feel intentional.
+Treat the checklist as a living runbook that survives founder vacations, vendor turnover and the first due-diligence call.
 
 ---


### PR DESCRIPTION
## Summary
- add a complete day-zero core services slide deck covering incorporation, domains, identity, devices, security and the first-week runbook
- provide companion narrative scripts including Sarah's DNS cautionary tale and operational guidance
- mark the corresponding task complete in the project TODO list

## Testing
- not run (content changes only)

------
https://chatgpt.com/codex/tasks/task_e_68de835904108325a559cc1af885f010