### PR TITLE
Add fractional CTO and MSP partnership content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -109,7 +109,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Cloud versus on-premise decisions, including free tier comparisons and container adoption timing
   - [x] Draft slides and narrative: Day zero assessment checklist covering identity, endpoint, backup and security controls
   - [x] Draft slides and narrative: Day zero core services setup—from incorporation and domains to devices—with Sarah's DNS cautionary tale
-  - [ ] Draft slides and narrative: Fractional CTO and MSP partnership models with evaluation questions
+  - [x] Draft slides and narrative: Fractional CTO and MSP partnership models with evaluation questions
   - [ ] Draft slides and narrative: Guest speaker ideas and the perspectives they bring to the session
   - [ ] Draft slides and narrative: Investor due diligence preparation, red flags and policy-to-board mapping tips
   - [ ] Draft slides and narrative: Legal compliance reality check across milestones, open source duties and privacy-by-design

--- a/content/part-06/fractional-cto-and-msps/narratives/01-intro.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/01-intro.md
@@ -1,0 +1,4 @@
+Speaker 1: Lean teams eventually hit a ceiling—product ambition outpaces leadership bandwidth.
+Speaker 2: That's when fractional CTOs and MSP partners start appearing in board meeting minutes.
+Speaker 1: The trick is to use them to accelerate maturity, not to abdicate the hard decisions.
+Speaker 2: So today we unpack when to bring each partner in and the questions that keep expectations sane.

--- a/content/part-06/fractional-cto-and-msps/narratives/02-why-fractional-leadership.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/02-why-fractional-leadership.md
@@ -1,4 +1,6 @@
 Speaker 1: Founders usually wait too long to admit they need senior guidance.
 Speaker 2: Right—fractional leaders exist because hiring a permanent CTO takes months and equity you can't spare.
 Speaker 1: Virtual CIOs and MSPs handle different pain: governance, policy, 24/7 operations.
+Speaker 2: Most engagements land in the 6 to 18 month window—long enough to stabilise, short enough to keep urgency high.
+Speaker 1: When cash is tight, trade 0.5 to 1 percent equity for part-time leadership instead of a $150k salary you can't cover yet.
 Speaker 2: Expect blended billing—retainers, day rates and per-incident fees—so model the spend before you commit.

--- a/content/part-06/fractional-cto-and-msps/narratives/02-why-fractional-leadership.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/02-why-fractional-leadership.md
@@ -1,0 +1,4 @@
+Speaker 1: Founders usually wait too long to admit they need senior guidance.
+Speaker 2: Right—fractional leaders exist because hiring a permanent CTO takes months and equity you can't spare.
+Speaker 1: Virtual CIOs and MSPs handle different pain: governance, policy, 24/7 operations.
+Speaker 2: Expect blended billing—retainers, day rates and per-incident fees—so model the spend before you commit.

--- a/content/part-06/fractional-cto-and-msps/narratives/03-when-to-engage.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/03-when-to-engage.md
@@ -1,0 +1,4 @@
+Speaker 1: Let's sort out who to call based on the mess in front of you.
+Speaker 2: Product roadmap chaos? A fractional CTO sets architecture guardrails and mentors engineering leads.
+Speaker 1: Board grilling you on IT risk? A virtual CIO can own policy cadence while the MSP implements the controls.
+Speaker 2: And if pager duty is burning everyone out, the MSP has to anchor the help desk and incident response.

--- a/content/part-06/fractional-cto-and-msps/narratives/04-partnership-models.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/04-partnership-models.md
@@ -1,0 +1,4 @@
+Speaker 1: Engagement shape matters just as much as who you hire.
+Speaker 2: An embedded fractional leader joins exec meetings weekly and steers hiring and architecture.
+Speaker 1: Some founders only need a six-week strategist to map the roadmap and hand off to their own team.
+Speaker 2: Co-managed MSPs keep product decisions in-house, but a full outsource risks skills atrophying if you don't stay engaged.

--- a/content/part-06/fractional-cto-and-msps/narratives/05-evaluating-fractional-cto.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/05-evaluating-fractional-cto.md
@@ -1,0 +1,4 @@
+Speaker 1: Vet a fractional CTO like you would a permanent exec.
+Speaker 2: Ask which stages they've navigated—seed, Series B, messy turnarounds—and what outcomes they achieved.
+Speaker 1: Availability matters; if they juggle five clients, who shows up when your production outage hits?
+Speaker 2: Request artifacts—architecture memos, hiring scorecards—and learn whether they coach, architect or swoop in as a fixer.

--- a/content/part-06/fractional-cto-and-msps/narratives/06-evaluating-msps.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/06-evaluating-msps.md
@@ -1,0 +1,4 @@
+Speaker 1: MSP due diligence can't stop at a glossy pitch deck.
+Speaker 2: Drill into incident response—who answers at 2 a.m. and what escalation path they follow.
+Speaker 1: Check their security posture and whether they'll integrate with your ticketing and SSO instead of adding silos.
+Speaker 2: And nail down the commercial model—after-hours rates, pass-through costs and the fine print on exit clauses.

--- a/content/part-06/fractional-cto-and-msps/narratives/07-promise-vs-delivery.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/07-promise-vs-delivery.md
@@ -1,4 +1,6 @@
 Speaker 1: Vendors love promising "unlimited" everything.
 Speaker 2: My favourite line is "we onboard in a week"—sure, if you don't mind copy-pasting scripts yourself.
 Speaker 1: Use humour to keep it human, but make them show the runbook, the ticket queue stats and who actually did the work.
+Speaker 2: When they boast "our AI monitors everything", I ask to see the alerts that drag them out of bed at 3 a.m.
+Speaker 1: And "seamless integration" translates to "tell me how many API calls your tooling will hammer our systems with".
 Speaker 2: If they can't laugh and still produce evidence, that's a red flag before you even sign.

--- a/content/part-06/fractional-cto-and-msps/narratives/07-promise-vs-delivery.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/07-promise-vs-delivery.md
@@ -1,0 +1,4 @@
+Speaker 1: Vendors love promising "unlimited" everything.
+Speaker 2: My favourite line is "we onboard in a week"—sure, if you don't mind copy-pasting scripts yourself.
+Speaker 1: Use humour to keep it human, but make them show the runbook, the ticket queue stats and who actually did the work.
+Speaker 2: If they can't laugh and still produce evidence, that's a red flag before you even sign.

--- a/content/part-06/fractional-cto-and-msps/narratives/08-due-diligence.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/08-due-diligence.md
@@ -1,0 +1,4 @@
+Speaker 1: References tell you how providers behave when things get messy.
+Speaker 2: Call past clients and ask how knowledge transfer went when the engagement ended.
+Speaker 1: Run a tabletop exercise before you sign—it reveals decision-making speed and tooling depth.
+Speaker 2: Don't forget subcontractors and insurance requirements; your customer contracts probably demand both.

--- a/content/part-06/fractional-cto-and-msps/narratives/09-governance.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/09-governance.md
@@ -1,0 +1,4 @@
+Speaker 1: Once the contract is signed, governance keeps everyone aligned.
+Speaker 2: Start with a RACI—who owns roadmap, change approvals, incident command and vendor spend.
+Speaker 1: Run quarterly reviews with shared dashboards so surprises surface early.
+Speaker 2: And agree on the exit plan now: documentation handover, credential rotation and how long they'll stay during transition.

--- a/content/part-06/fractional-cto-and-msps/narratives/10-takeaway.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/10-takeaway.md
@@ -1,0 +1,4 @@
+Speaker 1: Bottom line—fractional leaders and MSPs buy you time, not absolution.
+Speaker 2: Use sharp evaluation questions and a bit of humour to expose gaps before they turn into incidents.
+Speaker 1: Then govern the partnership like any critical system with clear roles and exit plans.
+Speaker 2: For homework, draft five evaluation questions for your stage and swap them with a peer for feedback.

--- a/content/part-06/fractional-cto-and-msps/narratives/outline.md
+++ b/content/part-06/fractional-cto-and-msps/narratives/outline.md
@@ -1,9 +1,9 @@
 # Narrative Outline — Working with Fractional CTOs and MSPs
 
 ## Tasks
-- [ ] Clarify when to engage fractional CTOs, virtual CIOs or MSP partners.
-- [ ] Capture the vendor humour about promises versus delivery to keep tone lively.
-- [ ] List questions founders should ask before signing support agreements.
+- [x] Clarify when to engage fractional CTOs, virtual CIOs or MSP partners.
+- [x] Capture the vendor humour about promises versus delivery to keep tone lively.
+- [x] List questions founders should ask before signing support agreements.
 
 ## Notes
 - Explain partnership models with fractional leaders and MSPs, including evaluation questions.

--- a/content/part-06/fractional-cto-and-msps/slides.md
+++ b/content/part-06/fractional-cto-and-msps/slides.md
@@ -4,5 +4,79 @@ title: Working with Fractional CTOs and MSPs
 ---
 
 # Working with Fractional CTOs and MSPs
+*Choosing the right leadership model for lean teams*
+
+---
+
+## Why fractional leadership exists
+- Start-ups need senior judgment before they can afford full-time executives
+- Fractional CTOs, virtual CIOs and MSPs fill different gaps across strategy, delivery and run operations
+- Typical engagements run 6–18 months until hiring a permanent leader or internal capability matures
+- Expect blended fees: day-rates for discovery, retainers for leadership time, per-incident or per-device MSP charges
+
+---
+
+## When to engage each partner type
+| Situation | Fractional CTO | Virtual CIO | Managed Service Provider |
+|-----------|----------------|-------------|--------------------------|
+| Product roadmap in flux | ✅ Sets architecture guardrails, mentors engineering leads | ⚠️ Provides governance but less hands-on | ❌ Focuses on run operations |
+| Board demanding IT controls | ⚠️ Can cover interim CIO duties | ✅ Owns policy, risk and budgeting cadence | ✅ Implements controls and monitoring |
+| 24/7 support gaps | ⚠️ Designs on-call model | ⚠️ Escalation owner | ✅ Runs help desk, NOC and incident response |
+| Major platform migration | ✅ Leads technical decision-making | ✅ Aligns roadmap with business priorities | ✅ Supplies delivery squads and change management |
+
+---
+
+## Partnership models and ownership
+- **Embedded fractional leader**: 1–2 days/week, attends exec meetings, drives architecture and hiring
+- **Project-based strategist**: 4–6 week discovery, hands over roadmap to internal team or MSP
+- **Co-managed MSP**: Provider runs service desk while founders retain product and security decisions
+- **Full outsource**: MSP controls infrastructure, releases and vendor management—risk of skill atrophy without oversight
+
+---
+
+## Evaluating fractional CTO candidates
+- What stage experience do they have (seed, Series A, turnaround) and which outcomes did they deliver?
+- How do they split time across clients and guarantee availability during incidents or board crunches?
+- Ask for artifacts: recent architecture memos, hiring scorecards, budget models
+- Probe for collaboration style with in-house engineers and product leads—coach, architect, or fixer?
+
+---
+
+## Evaluating MSP partners
+- Incident response expectations: who answers the 2 a.m. call and within which SLA window?
+- Security posture: SOC 2, ISO 27001, background checks, tooling stack for monitoring and patching
+- Integration depth: can they plug into your ticketing, SSO and asset inventory instead of running siloed tools?
+- Commercial transparency: rate cards for after-hours work, pass-through vendor costs, exit clause specifics
+
+---
+
+## The vendor promise vs delivery gap
+- Sales teams promise "unlimited support"—clarify concurrency limits and scope exclusions
+- Ask how many startups of your size they actively serve; beware being the smallest fish
+- Request real-world incident reviews: what went wrong, how communication flowed, lessons learned
+- Humour helps: "Show me the runbook, not just the glossy brochure" sets tone without burning bridges
+
+---
+
+## Due diligence and reference checks
+- Speak with at least two former clients about responsiveness and knowledge transfer at exit
+- Run a tabletop exercise during contracting to observe decision-making and tooling capabilities
+- Review subcontractor usage and ensure confidentiality clauses cover fractional leaders and MSP engineers
+- Align insurance requirements (cyber, professional indemnity) with your customer contracts
+
+---
+
+## Onboarding and ongoing governance
+- Define RACI across roadmap ownership, change approvals, vendor spend and incident command
+- Schedule joint quarterly business reviews with metrics dashboards and backlog updates
+- Capture intellectual property in shared repositories with clear licensing in contracts
+- Plan the exit: 30–60 day transition timeline, documentation handover and credential rotation
+
+---
+
+## Key takeaway
+Fractional CTOs and MSPs can accelerate maturity when paired thoughtfully.
+Use structured evaluation questions, humour to surface mismatched expectations and explicit governance to avoid abdication.
+Assignment: Draft five evaluation questions tailored to your current stage and share them with a peer for critique.
 
 ---

--- a/content/part-06/fractional-cto-and-msps/slides.md
+++ b/content/part-06/fractional-cto-and-msps/slides.md
@@ -13,6 +13,16 @@ title: Working with Fractional CTOs and MSPs
 - Fractional CTOs, virtual CIOs and MSPs fill different gaps across strategy, delivery and run operations
 - Typical engagements run 6–18 months until hiring a permanent leader or internal capability matures
 - Expect blended fees: day-rates for discovery, retainers for leadership time, per-incident or per-device MSP charges
+- Stage cues: pre-seed firms borrow architecture patterns, Series A scale to multi-region uptime, Series B demand compliance-rigour and portfolio planning
+- Equity trade-offs: 0.5–1% advisor equity versus a $150k cash salary keeps burn low when revenue is volatile
+
+---
+
+### Example: Series A SaaS Startup
+- **Situation**: 15-person team, scaling from 1K to 10K users in six months
+- **Challenge**: CTO departed mid-migration, roadmap slipped, board mandated security audit
+- **Solution**: 6-month fractional CTO to stabilise architecture and hiring paired with co-managed MSP for compliance automation
+- **Outcome**: Permanent CTO hired, SOC 2 audit passed on schedule, roadmap velocity recovered without losing key customers
 
 ---
 
@@ -26,11 +36,21 @@ title: Working with Fractional CTOs and MSPs
 
 ---
 
+### Typical Investment Levels
+- **Fractional CTO**: $8K–15K/month for 1–2 days per week, often with ramp-down clauses
+- **Virtual CIO**: $5K–10K/month covering governance, budgeting and board prep
+- **Co-managed MSP**: $3K–8K/month plus per-incident fees for after-hours or specialised work
+- **Budget rule**: Allocate 15–25% of the engineering/IT budget to external leadership to avoid starving internal capability
+- **Equity swaps**: Some leaders accept 0.25–0.5% options in lieu of cash—model dilution before agreeing
+
+---
+
 ## Partnership models and ownership
 - **Embedded fractional leader**: 1–2 days/week, attends exec meetings, drives architecture and hiring
 - **Project-based strategist**: 4–6 week discovery, hands over roadmap to internal team or MSP
-- **Co-managed MSP**: Provider runs service desk while founders retain product and security decisions
-- **Full outsource**: MSP controls infrastructure, releases and vendor management—risk of skill atrophy without oversight
+- **Co-managed MSP**: Provider runs service desk while founders retain product and security decisions; expect shared tooling within 30–60 days
+- **Full outsource**: MSP controls infrastructure, releases and vendor management—risk of skill atrophy without oversight and longer re-entry timeline
+- **Transition milestones**: Define 30-, 60- and 90-day checkpoints for documentation, tooling access and leadership cadence
 
 ---
 
@@ -55,6 +75,8 @@ title: Working with Fractional CTOs and MSPs
 - Ask how many startups of your size they actively serve; beware being the smallest fish
 - Request real-world incident reviews: what went wrong, how communication flowed, lessons learned
 - Humour helps: "Show me the runbook, not just the glossy brochure" sets tone without burning bridges
+- When they tout "AI monitoring everything", counter with "Great—show me the 3 a.m. alert stream and who triaged it"
+- If they promise "seamless integration", ask "How many API calls will your tooling make against our stack each hour?"
 
 ---
 
@@ -63,14 +85,34 @@ title: Working with Fractional CTOs and MSPs
 - Run a tabletop exercise during contracting to observe decision-making and tooling capabilities
 - Review subcontractor usage and ensure confidentiality clauses cover fractional leaders and MSP engineers
 - Align insurance requirements (cyber, professional indemnity) with your customer contracts
+- Protect intellectual property: stipulate source control access boundaries, invention assignment, and how strategic docs are stored
+- Watch for red flags: vague SLAs, resistance to documentation handover, or reliance on a single engineer for critical services
 
 ---
 
 ## Onboarding and ongoing governance
 - Define RACI across roadmap ownership, change approvals, vendor spend and incident command
 - Schedule joint quarterly business reviews with metrics dashboards and backlog updates
-- Capture intellectual property in shared repositories with clear licensing in contracts
+- Capture intellectual property in shared repositories with clear licensing in contracts and shared editing norms
+- Integrate external leaders into stand-ups, retros and architecture councils so internal teams retain voice and context
 - Plan the exit: 30–60 day transition timeline, documentation handover and credential rotation
+- Track performance: operational SLAs met, roadmap throughput, hiring progress and internal capability uplift
+
+---
+
+## Red Flags and Exit Strategies
+- **Warning signs**: Repeatedly delayed incident responses, scope creep without change control, thin documentation despite reminders
+- **Exit planning**: Keep 30-day notice baked into contracts, require handover checklists, insist on joint credential rotation
+- **Backup plans**: Maintain internal runbooks for critical systems, cross-train staff, avoid single points of failure in access or knowledge
+
+---
+
+## Industry, geography and scaling considerations
+- **Healthcare & FinTech**: Ensure partners can evidence HIPAA, PCI-DSS or local privacy compliance and support security questionnaires
+- **B2B SaaS**: Demand customer assurance support—MSP-ready answers for SOC 2, ISO 27001, and shared trust portals
+- **Consumer apps**: Focus on scaling infrastructure, CDN tuning and observability for viral usage spikes
+- **Geographic spread**: Align on time zones, language coverage and in-region data residency obligations
+- **Scaling decisions**: Define metrics (lead time, defect escape rate, customer NPS) that trigger transition from fractional to full-time leadership
 
 ---
 

--- a/content/part-06/fractional-cto-and-msps/slides.md
+++ b/content/part-06/fractional-cto-and-msps/slides.md
@@ -13,7 +13,7 @@ title: Working with Fractional CTOs and MSPs
 - Fractional CTOs, virtual CIOs and MSPs fill different gaps across strategy, delivery and run operations
 - Typical engagements run 6–18 months until hiring a permanent leader or internal capability matures
 - Expect blended fees: day-rates for discovery, retainers for leadership time, per-incident or per-device MSP charges
-- Stage cues: pre-seed firms borrow architecture patterns, Series A scale to multi-region uptime, Series B demand compliance-rigour and portfolio planning
+- Stage cues: pre-seed firms borrow architecture patterns, Series A scale to multi-region uptime, Series B demand compliance rigour and portfolio planning
 - Equity trade-offs: 0.5–1% advisor equity versus a $150k cash salary keeps burn low when revenue is volatile
 
 ---


### PR DESCRIPTION
## Summary
- expand the Part 6 fractional CTO and MSP module with complete slide content and partner evaluation guidance
- add narrative scripts covering engagement triggers, humour about vendor promises, due diligence and governance
- mark the corresponding Part 6 to-do item as complete and update the narrative outline tasks

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dedd81bb0c8325ae55913a99a947ee