### PR TITLE
Add guest speaker resources for startup IT session

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -110,7 +110,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Day zero assessment checklist covering identity, endpoint, backup and security controls
   - [x] Draft slides and narrative: Day zero core services setup—from incorporation and domains to devices—with Sarah's DNS cautionary tale
   - [x] Draft slides and narrative: Fractional CTO and MSP partnership models with evaluation questions
-  - [ ] Draft slides and narrative: Guest speaker ideas and the perspectives they bring to the session
+  - [x] Draft slides and narrative: Guest speaker ideas and the perspectives they bring to the session
   - [ ] Draft slides and narrative: Investor due diligence preparation, red flags and policy-to-board mapping tips
   - [ ] Draft slides and narrative: Legal compliance reality check across milestones, open source duties and privacy-by-design
   - [ ] Draft slides and narrative: Lightweight SaaS selection trade-offs and the Zoom-to-Teams migration case study

--- a/content/part-06/guest-speaker-ideas/narratives/01-intro.md
+++ b/content/part-06/guest-speaker-ideas/narratives/01-intro.md
@@ -1,0 +1,3 @@
+# Guest Speaker Ideas — Narrative
+
+Welcoming guest voices into the start-up IT module keeps the material grounded in reality. The aim of this segment is to highlight three complementary perspectives that expose learners to leadership, operational delivery and investor expectations. By curating diverse experiences we show founders and early operators what "good" and "risky" look like beyond theory.

--- a/content/part-06/guest-speaker-ideas/narratives/02-why-guest-voices.md
+++ b/content/part-06/guest-speaker-ideas/narratives/02-why-guest-voices.md
@@ -1,0 +1,3 @@
+## Why bring guest voices?
+
+Open with the rationale: founders have endless frameworks but rarely hear candid accounts of what actually happened during a crunch. Emphasise that each speaker translates a different pressure point—technical firefighting, service delivery promises and the scrutiny of outside capital. Call out that the goal is not inspirational talks; it is to interrogate decisions and trade-offs.

--- a/content/part-06/guest-speaker-ideas/narratives/03-fractional-cto.md
+++ b/content/part-06/guest-speaker-ideas/narratives/03-fractional-cto.md
@@ -1,0 +1,3 @@
+## Fractional CTO perspective
+
+Position the fractional CTO as the voice of experience when the wheels wobble. Have them walk through their first 90-day plan: stabilise the architecture, triage tech debt, prioritise hires and embed lightweight governance. Ask for stories contrasting a pre-seed engagement—where they're duct-taping shipping velocity—with a Series B client that needs compliance, forecasting and stakeholder management. Prompt them to discuss pitfalls like unclear decision rights, unpaid scope creep and what happens when teams assume an advisor is on-call 24/7. Close with a practical readiness checklist founders can complete before reaching out to fractional leaders.

--- a/content/part-06/guest-speaker-ideas/narratives/04-msp-account-manager.md
+++ b/content/part-06/guest-speaker-ideas/narratives/04-msp-account-manager.md
@@ -1,0 +1,3 @@
+## Startup-focused MSP account manager
+
+Introduce the MSP account manager as the operator who turns contracts into day-to-day coverage. Encourage them to deconstruct a typical co-managed support relationship: who fields which tickets, how they integrate tooling, what on-call escalation looks like in practice. Ask for anonymised SLA dashboards showing healthy and unhealthy trends so learners can interpret their own metrics. Cover pricing levers—per device, per user, compliance surcharges—and how those evolve with headcount or regulatory scope. Include guidance on running quarterly business reviews that focus on backlog burn-down and continuous improvement rather than endless upsells.

--- a/content/part-06/guest-speaker-ideas/narratives/05-vc-diligence-lead.md
+++ b/content/part-06/guest-speaker-ideas/narratives/05-vc-diligence-lead.md
@@ -1,0 +1,3 @@
+## VC diligence or portfolio operations lead
+
+Frame the investor representative as a reality check on what external stakeholders scrutinise. Have them outline their diligence checklist: security controls, revenue instrumentation, resilience plans, staffing and cultural signals. Request anonymised red and green flag examples pulled from data-room reviews—missing access logs, surprise shadow IT, or great runbooks that sped up approval. Explore how IT maturity shifts valuation conversations, board confidence and follow-on funding decisions. Reinforce that the best preparation is building diligence-ready documentation and repeating tabletop drills long before a term sheet appears.

--- a/content/part-06/guest-speaker-ideas/narratives/06-logistics-and-prep.md
+++ b/content/part-06/guest-speaker-ideas/narratives/06-logistics-and-prep.md
@@ -1,0 +1,3 @@
+## Logistics and prep tips
+
+Spell out the operating rhythm so organisers are not scrambling. Recommend sourcing speakers 6–8 weeks in advance, confirming NDAs, slide-sharing permissions and accessibility needs. Pair each guest with a learner moderator responsible for research, intros and audience questions; schedule a 30-minute prep call to align on flow. Provide context briefs that summarise audience maturity, session goals and no-go topics. Finally, plan to capture the session for reuse—obtain consent, organise recording and editing support, and publish assets to the cohort hub with clear access controls.

--- a/content/part-06/guest-speaker-ideas/narratives/07-call-to-action.md
+++ b/content/part-06/guest-speaker-ideas/narratives/07-call-to-action.md
@@ -1,0 +1,3 @@
+## Call to action
+
+Close the segment by nudging learners to practice outreach. Ask them to draft an email to their dream guest—highlighting the topic fit, proposed format, audience size and how they will make the speaker's time worthwhile. Invite a few volunteers to read their drafts and workshop improvements live. Reinforce that thoughtful preparation and a clear value exchange dramatically increase the hit rate when approaching busy leaders.

--- a/content/part-06/guest-speaker-ideas/narratives/outline.md
+++ b/content/part-06/guest-speaker-ideas/narratives/outline.md
@@ -1,9 +1,9 @@
 # Narrative Outline — Guest Speaker Ideas
 
 ## Tasks
-- [ ] Suggest a fractional CTO, startup-focused MSP account manager and VC diligence lead.
-- [ ] Explain what each guest can contribute to learner outcomes.
-- [ ] Capture logistics for sourcing and prepping each speaker.
+- [x] Suggest a fractional CTO, startup-focused MSP account manager and VC diligence lead.
+- [x] Explain what each guest can contribute to learner outcomes.
+- [x] Capture logistics for sourcing and prepping each speaker.
 
 ## Notes
 - List potential guest experts and the perspectives they bring to the session.

--- a/content/part-06/guest-speaker-ideas/slides.md
+++ b/content/part-06/guest-speaker-ideas/slides.md
@@ -4,5 +4,52 @@ title: Guest Speaker Ideas
 ---
 
 # Guest Speaker Ideas
+*Voices that make the session tangible*
+
+---
+
+## Why bring guest voices?
+- Anchor theory in lived experience across fractional leadership, MSP delivery and venture due diligence
+- Provide contrasting viewpoints on risk appetite, tooling investments and hiring choices
+- Offer networking opportunities for learners seeking mentors or advisory support
+- Humanise cautionary tales so teams remember the stakes when shortcuts seem tempting
+
+---
+
+## Fractional CTO perspective
+- Share the "first 90 days" playbook: architecture triage, hiring priorities and governance rituals
+- Contrast survival tactics for pre-seed scrappiness vs Series B controls
+- Highlight pitfalls: unclear decision rights, unpaid discovery work, treating advisory time as unlimited
+- Leave learners with a one-page readiness checklist before engaging fractional leaders
+
+---
+
+## Startup-focused MSP account manager
+- Illustrate how co-managed support actually runs—handoffs, tooling integration and after-hours cover
+- Bring real SLA dashboards and explain what healthy vs risky metrics look like
+- Discuss how pricing levers change with headcount, device mix and compliance demands
+- Coach teams on running quarterly business reviews that stay actionable instead of salesy
+
+---
+
+## VC diligence or portfolio operations lead
+- Demystify what investors check: security posture, revenue instrumentation, resilience plans
+- Explain how IT maturity influences valuation, board confidence and follow-on funding
+- Share anonymised red/green flags spotted during data-room reviews
+- Encourage founders to build "diligence-ready" documentation habits from day one
+
+---
+
+## Logistics and prep tips
+- Source speakers 6–8 weeks ahead; confirm NDAs and slide usage rights early
+- Pair each guest with a learner moderator and prep call agenda
+- Provide context briefs: audience maturity, time limits, desired takeaways
+- Capture sessions for reuse—secure consent, handle editing, and publish to the cohort hub
+
+---
+
+## Call to action
+Ask learners to draft an outreach email to their top-choice speaker and outline the value exchange offered.
+We workshop the best pitches live to build confidence in making the ask.
 
 ---

--- a/content/part-06/guest-speaker-ideas/slides.md
+++ b/content/part-06/guest-speaker-ideas/slides.md
@@ -21,6 +21,7 @@ title: Guest Speaker Ideas
 - Contrast survival tactics for pre-seed scrappiness vs Series B controls
 - Highlight pitfalls: unclear decision rights, unpaid discovery work, treating advisory time as unlimited
 - Leave learners with a one-page readiness checklist before engaging fractional leaders
+- They’ll help you understand why “it works on my machine” isn’t a deployment strategy
 
 ---
 
@@ -29,6 +30,7 @@ title: Guest Speaker Ideas
 - Bring real SLA dashboards and explain what healthy vs risky metrics look like
 - Discuss how pricing levers change with headcount, device mix and compliance demands
 - Coach teams on running quarterly business reviews that stay actionable instead of salesy
+- Learn the difference between “managed services” and “managed chaos”
 
 ---
 
@@ -37,6 +39,7 @@ title: Guest Speaker Ideas
 - Explain how IT maturity influences valuation, board confidence and follow-on funding
 - Share anonymised red/green flags spotted during data-room reviews
 - Encourage founders to build "diligence-ready" documentation habits from day one
+- Discover why your investor’s technical due diligence isn’t just checking if you have Wi-Fi
 
 ---
 


### PR DESCRIPTION
## Summary
- add detailed slide content covering fractional CTO, MSP, and VC diligence guest speakers for the start-up IT module
- provide supporting narrative scripts and logistics guidance for preparing and hosting each guest
- mark the corresponding to-do item for the session as complete

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e016b36ac0832588896f155d954666