### PR TITLE
Add investor due diligence prep content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -111,7 +111,7 @@ Use the checklist below to track progress for each part.
   - [x] Draft slides and narrative: Day zero core services setup—from incorporation and domains to devices—with Sarah's DNS cautionary tale
   - [x] Draft slides and narrative: Fractional CTO and MSP partnership models with evaluation questions
   - [x] Draft slides and narrative: Guest speaker ideas and the perspectives they bring to the session
-  - [ ] Draft slides and narrative: Investor due diligence preparation, red flags and policy-to-board mapping tips
+  - [x] Draft slides and narrative: Investor due diligence preparation, red flags and policy-to-board mapping tips
   - [ ] Draft slides and narrative: Legal compliance reality check across milestones, open source duties and privacy-by-design
   - [ ] Draft slides and narrative: Lightweight SaaS selection trade-offs and the Zoom-to-Teams migration case study
   - [ ] Draft slides and narrative: Mock vendor evaluation role-play structure and discussion prompts

--- a/content/part-06/investor-due-diligence-prep/narratives/01.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/01.md
@@ -1,4 +1,4 @@
-Speaker 1: [confident] Sarah's seed deck promised investors she could scale without burning the place down; now Series A questions are landing in her inbox daily.
+Speaker 1: [confident] Sarah's seed deck promised investors she could scale without burning the place down—or turning the office into a literal or metaphorical dumpster fire; now Series A questions are landing in her inbox daily.
 Speaker 2: The slides we’re about to walk through are the playbook for proving that promise isn’t just marketing glitter.
 Speaker 1: Think of due diligence prep like running production change management—clear owners, change logs and rollback plans.
 Speaker 2: And just like change management, the calm comes from having evidence ready before anything breaks in front of the board.

--- a/content/part-06/investor-due-diligence-prep/narratives/01.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/01.md
@@ -1,0 +1,4 @@
+Speaker 1: [confident] Sarah's seed deck promised investors she could scale without burning the place down; now Series A questions are landing in her inbox daily.
+Speaker 2: The slides we’re about to walk through are the playbook for proving that promise isn’t just marketing glitter.
+Speaker 1: Think of due diligence prep like running production change management—clear owners, change logs and rollback plans.
+Speaker 2: And just like change management, the calm comes from having evidence ready before anything breaks in front of the board.

--- a/content/part-06/investor-due-diligence-prep/narratives/02.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/02.md
@@ -1,4 +1,4 @@
 Speaker 1: [analytical] Series A partners now assume you've got discipline around finance, security and customer retention.
 Speaker 2: When they ask, "Show me your churn cohorts and your incident history," they're testing whether growth has guardrails.
-Speaker 1: The fastest way to erode confidence is to stall or improvise—every "let me get back to you" adds friction to the deal.
+Speaker 1: That pivot from pipeline to pen tests is their way of confirming discipline, so the fastest way to erode confidence is to stall or improvise—every "let me get back to you" adds friction to the deal.
 Speaker 2: That’s why we start aligning evidence months before the outreach email ever hits an investor’s inbox.

--- a/content/part-06/investor-due-diligence-prep/narratives/02.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/02.md
@@ -1,0 +1,4 @@
+Speaker 1: [analytical] Series A partners now assume you've got discipline around finance, security and customer retention.
+Speaker 2: When they ask, "Show me your churn cohorts and your incident history," they're testing whether growth has guardrails.
+Speaker 1: The fastest way to erode confidence is to stall or improvise—every "let me get back to you" adds friction to the deal.
+Speaker 2: That’s why we start aligning evidence months before the outreach email ever hits an investor’s inbox.

--- a/content/part-06/investor-due-diligence-prep/narratives/03.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/03.md
@@ -1,4 +1,4 @@
 Speaker 1: [structured] We break diligence into three streams so nothing falls between departments.
 Speaker 2: Finance owns cash, contracts and SOC 2 timelines; security tracks access controls and incidents; product captures roadmap and customer promises.
-Speaker 1: A program manager or chief of staff keeps everyone aligned, running the same cadence as sprint reviews.
+Speaker 1: A program manager or chief of staff keeps everyone aligned, running the same cadence as sprint reviews—finance demos burn forecasts, security closes the "12 admin accounts" story, product shows roadmap deltas.
 Speaker 2: Weekly stand-ups and a single tracker give investors confidence that the team can execute across silos.

--- a/content/part-06/investor-due-diligence-prep/narratives/03.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/03.md
@@ -1,0 +1,4 @@
+Speaker 1: [structured] We break diligence into three streams so nothing falls between departments.
+Speaker 2: Finance owns cash, contracts and SOC 2 timelines; security tracks access controls and incidents; product captures roadmap and customer promises.
+Speaker 1: A program manager or chief of staff keeps everyone aligned, running the same cadence as sprint reviews.
+Speaker 2: Weekly stand-ups and a single tracker give investors confidence that the team can execute across silos.

--- a/content/part-06/investor-due-diligence-prep/narratives/04.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/04.md
@@ -1,4 +1,4 @@
-Speaker 1: [practical] Treat the data room like a product release—versioned, documented and curated.
-Speaker 2: Every file needs a cover note explaining what it is, why it matters and the last review date.
-Speaker 1: Sarah colour-codes action items with due dates so investors see momentum instead of a pile of gaps.
-Speaker 2: Sensitive exports stay in watermark-enabled folders with access logs; no more "here's a spreadsheet" emails floating around.
+Speaker 1: [practical] Treat the data room like a product release—versioned, documented and curated, with a changelog that shows new evidence landing every week.
+Speaker 2: Every file needs a cover note explaining what it is, why it matters and the last review date, plus a contact person if investors want a deeper dive.
+Speaker 1: Sarah colour-codes action items with due dates so investors see momentum instead of a pile of gaps, and she tags blockers that need board attention.
+Speaker 2: Sensitive exports stay in watermark-enabled folders with access logs; no more "here's a spreadsheet" emails floating around, and expirations auto-trigger reminders to revoke access.

--- a/content/part-06/investor-due-diligence-prep/narratives/04.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/04.md
@@ -1,0 +1,4 @@
+Speaker 1: [practical] Treat the data room like a product release—versioned, documented and curated.
+Speaker 2: Every file needs a cover note explaining what it is, why it matters and the last review date.
+Speaker 1: Sarah colour-codes action items with due dates so investors see momentum instead of a pile of gaps.
+Speaker 2: Sensitive exports stay in watermark-enabled folders with access logs; no more "here's a spreadsheet" emails floating around.

--- a/content/part-06/investor-due-diligence-prep/narratives/05.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/05.md
@@ -1,0 +1,4 @@
+Speaker 1: [alert] Security questionnaires look intimidating, but most questions repeat: MFA, pen tests, backups, privacy.
+Speaker 2: We front-load our red flags—shared admin accounts, missing asset inventories—so investors see honesty, not surprise.
+Speaker 1: Each gap gets a mitigation plan with owner, budget and timeline; no vague "we're working on it" responses.
+Speaker 2: A plain-language FAQ helps translate acronyms into outcomes for investors and board members who aren’t security natives.

--- a/content/part-06/investor-due-diligence-prep/narratives/05.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/05.md
@@ -1,4 +1,4 @@
 Speaker 1: [alert] Security questionnaires look intimidating, but most questions repeat: MFA, pen tests, backups, privacy.
 Speaker 2: We front-load our red flags—shared admin accounts, missing asset inventories—so investors see honesty, not surprise.
-Speaker 1: Each gap gets a mitigation plan with owner, budget and timeline; no vague "we're working on it" responses.
+Speaker 1: Each gap gets a mitigation plan with owner, budget and timeline; for example, "12 privileged accounts without MFA, YubiKey rollout funded at $15k and complete by June 30." No vague "we're working on it" responses.
 Speaker 2: A plain-language FAQ helps translate acronyms into outcomes for investors and board members who aren’t security natives.

--- a/content/part-06/investor-due-diligence-prep/narratives/06.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/06.md
@@ -1,4 +1,6 @@
 Speaker 1: [governed] Investors want to know who actually signs off on risk.
 Speaker 2: We map every policy to a board sponsor or advisor—security charter to the risk chair, finance controls to the audit lead.
-Speaker 1: Decision logs show when exceptions were approved and by whom; it proves governance is active, not theoretical.
-Speaker 2: A shared calendar connecting audits, board reviews and certification renewals keeps everyone in rhythm.
+Speaker 1: Decision logs show when exceptions were approved and by whom; it proves governance is active, not theoretical, and highlights when legal or product weighed in.
+Speaker 2: A shared calendar connecting audits, board reviews and certification renewals keeps everyone in rhythm, with reminders like "Q2 risk committee + SOC 2 dry run" baked in.
+Speaker 1: When the partner asks "Who closes the loop?" we point to the governance RACI and invite them to our next tabletop recap.
+Speaker 2: That transparency signals maturity—it feels like they're joining an existing cadence instead of inventing one mid diligence.

--- a/content/part-06/investor-due-diligence-prep/narratives/06.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/06.md
@@ -1,0 +1,4 @@
+Speaker 1: [governed] Investors want to know who actually signs off on risk.
+Speaker 2: We map every policy to a board sponsor or advisor—security charter to the risk chair, finance controls to the audit lead.
+Speaker 1: Decision logs show when exceptions were approved and by whom; it proves governance is active, not theoretical.
+Speaker 2: A shared calendar connecting audits, board reviews and certification renewals keeps everyone in rhythm.

--- a/content/part-06/investor-due-diligence-prep/narratives/07.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/07.md
@@ -1,4 +1,4 @@
 Speaker 1: [data-driven] Dashboards alone won't close a round, but they anchor the story in facts.
-Speaker 2: Quarterly posture reports, uptime achievements and MTTR trends show resilience in motion.
-Speaker 1: Pair the charts with narratives—"here’s the remediation we shipped after that pen test"—so investors hear accountability.
-Speaker 2: We also surface how the risk register feeds Jira or Notion; governance without execution is just wallpaper.
+Speaker 2: Quarterly posture reports, uptime achievements and MTTR trends show resilience in motion—"99.6% SLA hit, 12-minute MTTR" reads better than buzzwords.
+Speaker 1: Pair the charts with narratives—"here’s the remediation we shipped after that pen test"—so investors hear accountability and progress.
+Speaker 2: We also surface how the risk register feeds Jira or Notion; governance without execution is just wallpaper, and burndown charts prove tasks actually close.

--- a/content/part-06/investor-due-diligence-prep/narratives/07.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/07.md
@@ -1,0 +1,4 @@
+Speaker 1: [data-driven] Dashboards alone won't close a round, but they anchor the story in facts.
+Speaker 2: Quarterly posture reports, uptime achievements and MTTR trends show resilience in motion.
+Speaker 1: Pair the charts with narratives—"here’s the remediation we shipped after that pen test"—so investors hear accountability.
+Speaker 2: We also surface how the risk register feeds Jira or Notion; governance without execution is just wallpaper.

--- a/content/part-06/investor-due-diligence-prep/narratives/08.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/08.md
@@ -1,0 +1,4 @@
+Speaker 1: [coaching] Before the real investors arrive, we run a mock session with our advisors playing the tough crowd.
+Speaker 2: Each exec practices a two-sentence answer with a pointer to deeper artefacts—no wandering monologues.
+Speaker 1: We record the rehearsal, capture follow-up tasks and assign owners in the tracker within the hour.
+Speaker 2: That loop builds muscle memory so the actual diligence call feels like a rerun, not improv night.

--- a/content/part-06/investor-due-diligence-prep/narratives/09.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/09.md
@@ -1,0 +1,4 @@
+Speaker 1: [career-minded] Startups lean on program managers or chiefs of staff to keep diligence humming.
+Speaker 2: They partner with security or compliance leads who can translate questionnaires into sprint-sized work.
+Speaker 1: Finance and RevOps double-check the numbers and customer obligations so nothing surprises the board.
+Speaker 2: People who thrive here love diplomacy and structured storytelling—the same skills that lead to VP Ops or trust leadership roles later.

--- a/content/part-06/investor-due-diligence-prep/narratives/10.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/10.md
@@ -1,0 +1,4 @@
+Speaker 1: [wrap-up] The big lesson—start six months early and treat diligence like an ongoing product, not a last-minute fire drill.
+Speaker 2: When policies, metrics and board oversight line up, investors feel like they're joining a machine that already runs.
+Speaker 1: Red flags are inevitable, but owning them with a remediation plan shows maturity, not weakness.
+Speaker 2: And that transparency is exactly what keeps term sheets moving instead of gathering dust in legal review.

--- a/content/part-06/investor-due-diligence-prep/narratives/outline.md
+++ b/content/part-06/investor-due-diligence-prep/narratives/outline.md
@@ -1,9 +1,9 @@
 # Narrative Outline — Preparing for Investor Due Diligence
 
 ## Tasks
-- [ ] Walk through sample security questionnaires and common red flags.
-- [ ] Connect preparedness to maintaining investor confidence.
-- [ ] Provide guidance on mapping policies to board expectations.
+- [x] Walk through sample security questionnaires and common red flags.
+- [x] Connect preparedness to maintaining investor confidence.
+- [x] Provide guidance on mapping policies to board expectations.
 
 ## Notes
 - Describe diligence artifacts, common red flags and policy-to-board mapping tips.

--- a/content/part-06/investor-due-diligence-prep/slides.md
+++ b/content/part-06/investor-due-diligence-prep/slides.md
@@ -4,5 +4,78 @@ title: Preparing for Investor Due Diligence
 ---
 
 # Preparing for Investor Due Diligence
+*Give investors confidence that controls match the story*
 
+---
+
+## Why diligence heats up post-Seed
+- Series A/B investors expect proof that security, finance and compliance scale with revenue.
+- Unanswered questions slow down term sheets and spook co-investors.
+- Sarah's seed deck promised "enterprise-ready"—now she must show receipts.
+- Preparing early buys founders time when the data room inevitably expands.
+
+---
+
+## Core workstreams to coordinate
+- **Financial & operational** – cash runway, burn, vendor commitments, SOC 2 roadmap.
+- **Security & infrastructure** – access controls, incident history, backup testing evidence.
+- **Product & customers** – roadmap dependencies, SLAs, churn and expansion metrics.
+- Assign an owner per stream (CFO, CTO, RevOps) with a single program manager stitching updates together.
+
+---
+
+## Building a living data room
+- Centralise policies, architecture diagrams, vendor contracts and board minutes with version control.
+- Include short context notes so outsiders understand why a document matters.
+- Track open actions with due dates—investors value visibility more than perfection.
+- Keep sensitive exports (e.g. customer lists) in controlled folders with watermarking and access logs.
+
+---
+
+## Security questionnaire watch-outs
+- Identify common asks: MFA coverage, penetration test cadence, disaster recovery drills, privacy compliance.
+- Flag red signals early—shared admin accounts, missing asset inventory, stale incident response plans.
+- Draft honest mitigation plans instead of hand-waving; investors reward realism.
+- Maintain a FAQ that translates technical control names into plain language for partners and board members.
+
+---
+
+## Map policies to governance expectations
+- Tie each policy to the board committee or advisor who sponsors it (e.g. audit, risk, security).
+- Summarise decision rights: who approves exceptions, how often reviews occur, what evidence is logged.
+- Highlight how legal, finance and engineering collaborate on compliance checkpoints.
+- Provide a calendar linking board meetings, audits and certification renewals.
+
+---
+
+## Evidence and metrics investors trust
+- Share quarterly security posture reports, uptime SLAs achieved, mean-time-to-recover trends.
+- Bundle SOC 2 gap assessments, vulnerability remediation stats and third-party attestations.
+- Pair qualitative narratives with dashboards so numbers land with context.
+- Show how risk registers flow into product and operations backlogs for execution.
+
+---
+
+## Rehearse the diligence conversation
+- Run a mock Q&A with advisors posing as investors; record it for coaching.
+- Equip every exec with a "two-sentence answer + escalation" script for their domain.
+- Prepare backup slides for deeper dives—architecture, vendor matrix, privacy controls.
+- Log follow-ups immediately so nothing slips between meetings.
+
+---
+
+## Roles, traits and progression
+- **Program manager / Chief of staff** – orchestrates data room updates, keeps stakeholders aligned.
+- **Security or compliance lead** – translates questionnaires into actionable backlog items.
+- **Finance & RevOps partners** – validate metrics and customer contract obligations.
+- Thrives on diplomacy, attention to detail and appetite for structured storytelling.
+- Career paths lead to VP Operations, Head of Trust & Safety or venture portfolio advisor roles.
+
+---
+
+## Key takeaways
+- Start gathering evidence six months before you fundraise; crisis-mode prep shows in every answer.
+- Treat the data room as a living product with owners, release notes and guardrails.
+- Red flags are inevitable—own them, show remediation progress and connect it to board oversight.
+- Investor confidence grows when policies, metrics and narratives reinforce one another.
 ---

--- a/content/part-06/investor-due-diligence-prep/slides.md
+++ b/content/part-06/investor-due-diligence-prep/slides.md
@@ -11,7 +11,7 @@ title: Preparing for Investor Due Diligence
 ## Why diligence heats up post-Seed
 - Series A/B investors expect proof that security, finance and compliance scale with revenue.
 - Unanswered questions slow down term sheets and spook co-investors.
-- Sarah's seed deck promised "enterprise-ready"—now she must show receipts.
+- Sarah's seed deck promised "enterprise-ready"—now she must show receipts, not artisanal buzzword salad.
 - Preparing early buys founders time when the data room inevitably expands.
 
 ---
@@ -34,6 +34,7 @@ title: Preparing for Investor Due Diligence
 
 ## Security questionnaire watch-outs
 - Identify common asks: MFA coverage, penetration test cadence, disaster recovery drills, privacy compliance.
+- Expect specifics like "What percentage of privileged accounts enforce MFA?"—"82% today, moving to 100% by Q2 via YubiKeys" beats evasive answers.
 - Flag red signals early—shared admin accounts, missing asset inventory, stale incident response plans.
 - Draft honest mitigation plans instead of hand-waving; investors reward realism.
 - Maintain a FAQ that translates technical control names into plain language for partners and board members.
@@ -44,13 +45,13 @@ title: Preparing for Investor Due Diligence
 - Tie each policy to the board committee or advisor who sponsors it (e.g. audit, risk, security).
 - Summarise decision rights: who approves exceptions, how often reviews occur, what evidence is logged.
 - Highlight how legal, finance and engineering collaborate on compliance checkpoints.
-- Provide a calendar linking board meetings, audits and certification renewals.
+- Share a governance calendar: Q1 risk committee + SOC 2 readiness review, Q2 audit committee + PCI scan, Q3 full board + cyber tabletop, Q4 certification renewals.
 
 ---
 
 ## Evidence and metrics investors trust
-- Share quarterly security posture reports, uptime SLAs achieved, mean-time-to-recover trends.
-- Bundle SOC 2 gap assessments, vulnerability remediation stats and third-party attestations.
+- Share quarterly security posture reports, uptime SLAs achieved (99.5%+ is Series A table stakes, 99.9% a stretch goal), mean-time-to-recover trends.
+- Bundle SOC 2 gap assessments, vulnerability remediation stats (e.g. 95% of critical vulns closed <14 days) and third-party attestations.
 - Pair qualitative narratives with dashboards so numbers land with context.
 - Show how risk registers flow into product and operations backlogs for execution.
 
@@ -58,24 +59,64 @@ title: Preparing for Investor Due Diligence
 
 ## Rehearse the diligence conversation
 - Run a mock Q&A with advisors posing as investors; record it for coaching.
-- Equip every exec with a "two-sentence answer + escalation" script for their domain.
+- Equip every exec with a "two-sentence answer + escalation" script for their domain—"Our incident response playbook assigns roles within 15 minutes, then hands to the CISO-led war room; want to see the drill notes?".
 - Prepare backup slides for deeper dives—architecture, vendor matrix, privacy controls.
 - Log follow-ups immediately so nothing slips between meetings.
 
 ---
 
 ## Roles, traits and progression
-- **Program manager / Chief of staff** – orchestrates data room updates, keeps stakeholders aligned.
-- **Security or compliance lead** – translates questionnaires into actionable backlog items.
-- **Finance & RevOps partners** – validate metrics and customer contract obligations.
+- **Program manager / Chief of staff** – orchestrates data room updates, keeps stakeholders aligned. Typical comp: $140k–$190k + equity at Series A/B.
+- **Security or compliance lead** – translates questionnaires into actionable backlog items. Expect $160k–$210k, often paired with bonus tied to audit milestones.
+- **Finance & RevOps partners** – validate metrics and customer contract obligations; senior managers sit $130k–$170k with upside at close.
 - Thrives on diplomacy, attention to detail and appetite for structured storytelling.
 - Career paths lead to VP Operations, Head of Trust & Safety or venture portfolio advisor roles.
+- Map progression milestones (owning first diligence cycle, leading certification renewals, joining board meetings) so the team sees a runway.
+
+---
+
+## Legal and regulatory readiness
+- Catalogue applicable regulations early: GDPR/UK GDPR, CCPA/CPRA, HIPAA or SOC 2 depending on vertical.
+- Document lawful bases for processing, data retention standards and DPA coverage for every critical vendor.
+- Show international scaling awareness—data residency in the EU, onshore support SLAs for APAC, breach notification variations.
+- Partner legal and security leads on a quarterly compliance checkpoint so surprises surface before term sheet negotiations.
+
+---
+
+## Timeline and critical path
+- Typical diligence cycles span 6–10 weeks from data room access to close; plan backward from your cash runway.
+- Week 1–2: data room review and follow-up questions; Week 3–5: deep dives with functional leaders; Week 6–8: confirmatory audits and customer calls.
+- Highlight dependencies—SOC 2 Type II report delivery, customer reference availability, legal opinion drafting.
+- Maintain a RAID log so risks, assumptions, issues and decisions stay visible to executives and investors.
+
+---
+
+## Case study: NimbusPay Series A
+- Day 0: pre-seeded data room with 120 curated artifacts, ownership tracker in Notion.
+- Day 14: investors flagged MFA gaps; remediation plan committed to 100% hardware keys in 45 days with $15k budget.
+- Day 35: cross-border payroll expansion triggered GDPR transfer impact assessment and Canadian PIPEDA review.
+- Day 52: diligence closed after mock board review confirmed policy-to-governance alignment and incident drill readiness.
+
+---
+
+## Red flags hall of fame (and fixes)
+- "Security lead" is a contractor 5 hours/week → solution: interim virtual CISO backed by engineering manager accountable for controls.
+- No incident response drill since founding → schedule tabletop within 30 days, document after-action and add to board pack.
+- Customer data stored in shared S3 bucket with ex-employee access → run access audit, enable object lock, revoke stale keys same week.
+- Legal can't articulate data residency commitments → map contractual obligations, document sub-processors, update privacy notice.
+
+---
+
+## Resources and templates
+- Diligence tracker template: executive owner matrix + follow-up SLA checklist.
+- Recommended tools: Tugboat Logic or Drata for control evidence, Notion/Confluence for playbooks, Vanta-style dashboards for KPIs.
+- Reading list: NIST CSF profiles for startups, AICPA SOC 2 implementation guide, "Secure SaaS" podcast episodes 12–15.
+- Share a partner directory (fractional CFOs, privacy counsel, IR advisors) to scale support as demands grow.
 
 ---
 
 ## Key takeaways
-- Start gathering evidence six months before you fundraise; crisis-mode prep shows in every answer.
+- Start gathering evidence six months before you fundraise; aim for annual-physical calm, not emergency-room chaos.
 - Treat the data room as a living product with owners, release notes and guardrails.
 - Red flags are inevitable—own them, show remediation progress and connect it to board oversight.
 - Investor confidence grows when policies, metrics and narratives reinforce one another.
----


### PR DESCRIPTION
## Summary
- expand the investor due diligence lesson with detailed slide content covering workstreams, governance links, metrics and rehearsals
- add accompanying narrative scripts that walk through questionnaires, red flags and board expectation mapping
- mark the corresponding to-do checklist item complete in TODO.md

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e28d6c822c83258ca7f946fdd290cb