### PR TITLE
Add diagram suggestions for course content

### DIFF
--- a/docs/diagram-suggestions.md
+++ b/docs/diagram-suggestions.md
@@ -1,0 +1,16 @@
+# Diagram and Illustration Ideas
+
+## Incident vs Request Fulfilment (Part 1)
+- Create a flowchart that branches on "service degraded?" and "pre-approved workflow?" leading to either the Incident path or Request path. Use colour-coding for urgency to reflect the MTTR focus on incidents versus satisfaction focus on requests.
+
+## Service Value Chain (Part 1)
+- Add a wheel or cyclical diagram mapping "Plan → Improve → Engage → Design & Transition → Obtain/Build → Deliver & Support" with arrows to show continual improvement and feedback loops across activities.
+
+## DORA Metrics Overview (Part 3)
+- Include a quadrant or radar chart that plots Deployment Frequency, Lead Time, Change Failure Rate and MTTR to visually contrast current vs target performance.
+
+## Vendor Engagement Funnel & MSP Hand-overs (Part 5)
+- Insert a funnel graphic showing the five stages (Awareness & Outreach → Qualification & Discovery → Proposal Review & Due Diligence → Contracting & Onboarding → Operate & Improve) with swim-lanes for IT, finance, legal, and MSP to clarify ownership at each step.
+
+## Post-Mortem Agenda (Part 4)
+- Provide a timeline illustration of a typical post-incident review, highlighting when each role (responder, service owner, facilitator, scribe, business stakeholder) contributes and where documentation is captured.


### PR DESCRIPTION
## Summary
- add a diagram-suggestions document covering key course modules
- outline potential visuals for ITIL basics, DevOps metrics, vendor funnel, and post-mortem flow

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692593c5d1f08325a2855b4f57769391)