### PR TITLE
Update Claude workflows to claude-code-action v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,14 +20,14 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,45 +36,28 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
-          #anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+
+          # Prompt for automated review (no @claude mention needed)
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
+
+          # Model and other Claude CLI flags. In v1 these replace the former
+          # top-level `model:` input.
+          claude_args: |
+            --model claude-opus-5
+
           # Optional: Skip review for certain conditions
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude-content-review.yml
+++ b/.github/workflows/claude-content-review.yml
@@ -1,4 +1,4 @@
-name: Claude Code Review
+name: Claude Content Review
 
 on:
   pull_request:
@@ -8,20 +8,20 @@ on:
       - "content/**"
 
 jobs:
-  claude-review:
+  claude-content-review:
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -29,47 +29,30 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Content Review
-        id: claude-review
-        uses: anthropics/claude-code-action@beta
+        id: claude-content-review
+        uses: anthropics/claude-code-action@v1
         with:
-          #anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+
+          # Prompt for automated review (no @claude mention needed)
+          prompt: |
             Please review the content that has been added with this review. The goal is to
             provide useful information for a university-level professional practice unit for
             people without IT experience to learn how to operate in various kinds of IT organisation.
- 
+
             Each slide should be about 100-200 words (i.e. about a minute to two minutes of talking).
-           
-            If you see that there is relevant content or topics that could be talked about that are missing, 
+
+            If you see that there is relevant content or topics that could be talked about that are missing,
             suggest them. Suggest improvements to the conversational flow of the dialog. Identify where
             a concrete example would be helpful. Identify where humour could be added appropriately.
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
+
+          # Model and other Claude CLI flags. In v1 these replace the former
+          # top-level `model:` input.
+          claude_args: |
+            --model claude-opus-5
+
           # Optional: Skip review for certain conditions
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,29 +31,22 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
+
+          # Model and other Claude CLI flags. In v1 these replace the former
+          # top-level `model:`, `allowed_tools:` and `custom_instructions:`
+          # inputs (now --model, --allowedTools, --append-system-prompt).
+          claude_args: |
+            --model claude-opus-5
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
-          
+
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
-          
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
+
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-


### PR DESCRIPTION
## Summary

The three Claude workflows were still pinned to the v0.x `@beta` tag and used v0 input names. This moves them to `@v1` and updates the inputs to match, verified against the action's v1 migration guide rather than from memory.

## Changes

| v0 (previous) | v1 (now) |
| --- | --- |
| `anthropics/claude-code-action@beta` | `@v1` |
| `direct_prompt:` | `prompt:` |
| `model:` (commented out) | `claude_args:` → `--model claude-opus-5` |

- **`model` no longer exists as a top-level input in v1.** Model selection moved into `claude_args` as a CLI flag, so the commented-out line would have failed had anyone uncommented it. Its example value (`claude-opus-4-20250514`) is deprecated regardless.
- **Removed commented-out template blocks** referencing inputs that v1 dropped — `direct_prompt` variants, `allowed_tools`, `custom_instructions`. Leaving them would document a removed API. The `if:` filter comments are still valid Actions syntax and are kept.
- Removed a duplicated commented-out `anthropic_api_key` line.

## Naming collision fixed

`claude-code-review.yml` and `claude-content-review.yml` both declared `name: Claude Code Review` with job id `claude-review`. On a PR they therefore appeared as two indistinguishable `claude-review` checks — visible on #132, where both failed and neither could be told apart. The content workflow is now `Claude Content Review` with job id `claude-content-review`.

## Deliberately not changed

Both review workflows still pass **both** `anthropic_api_key` and `claude_code_oauth_token`. The v1 docs state exactly one auth method is required, so this looks wrong — but the jobs on #132 authenticated successfully (they got far enough to post a PR comment), and which secret is actually populated is not visible from the working environment. Removing the wrong one would break CI, so it is flagged here rather than guessed at. If you know which is set, it is a one-line delete.

`--max-turns` was also left out, to keep this scoped to a version bump rather than a behaviour change.

## Testing

All five workflow files parse as valid YAML, and the two review workflows now resolve to distinct names and job ids:

```
ok   claude-code-review.yml         name='Claude Code Review'      jobs=['claude-review']
ok   claude-content-review.yml      name='Claude Content Review'   jobs=['claude-content-review']
ok   claude.yml                     name='Claude Code'             jobs=['claude']
```

Note that this branch touches only `.github/workflows/**`, so it does not match the `paths` filter of either review workflow — **opening this PR will not exercise the changed workflows.** They will first run on the next PR that touches `content/**` or a `.py`/`.sh`/`.go` file.

The stale `@beta` ref remains a *hypothesis* for the "Claude encountered an error" failures seen on #132; the job logs showed `CLAUDE_SUCCESS: false` with no diagnostic. This may fix them, or may not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HxxwX5fZ4Kjd3AWCarPHT

---
_Generated by [Claude Code](https://claude.ai/code/session_014HxxwX5fZ4Kjd3AWCarPHT)_